### PR TITLE
Lombok Fix

### DIFF
--- a/ecm-core/src/main/java/com/ecm/core/sanity/SanityCheckReport.java
+++ b/ecm-core/src/main/java/com/ecm/core/sanity/SanityCheckReport.java
@@ -1,6 +1,7 @@
 package com.ecm.core.sanity;
 
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -14,7 +15,9 @@ public class SanityCheckReport {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private Status status;
+    @Default
     private List<String> issues = new ArrayList<>();
+    @Default
     private List<String> fixes = new ArrayList<>();
     private int itemsChecked;
     private int issuesFound;


### PR DESCRIPTION
## Summary
Fix Lombok @Builder warnings by adding @Builder.Default to fields with initializing expressions. This ensures builder-created instances preserve the default ArrayList values for issues and fixes fields, and removes noisy warnings from mvn test / mvn verify.

## Related Issues
Closes #1

## Changes
  - Added @Builder.Default annotation to issues field in SanityCheckReport.java
  - Added @Builder.Default annotation to fixes field in SanityCheckReport.java
  - Added import for lombok.Builder.Default

## Testing
mvn test
  # Expected: No Lombok warnings for SanityCheckReport
  # Builder-created instances have non-null issues/fixes lists by default

## Screenshots (UI)
N/A - Backend change only.

## Config/Env Changes
None.

## Checklist
  - Conventional Commit title
  - Tests added/updated
  - Docs updated (AGENTS.md/README)
  - Backward compatible / migration noted

