### PR TITLE
test: add search acl regression coverage

### DIFF
--- a/docs/DESIGN_SEARCH_ACL_REGRESSION_20260110.md
+++ b/docs/DESIGN_SEARCH_ACL_REGRESSION_20260110.md
@@ -1,0 +1,16 @@
+# Design: Search ACL Regression Coverage (2026-01-10)
+
+## Goal
+- Add targeted regression coverage for ACL-filtered search results across backend and E2E flows.
+
+## Approach
+- Backend: extend search ACL unit tests to cover empty permission outcomes and available facet filtering.
+- E2E: add a role-based search scenario to ensure viewer users cannot see explicitly restricted documents.
+
+## Impact
+- Prevents regressions where unauthorized results or facets leak into search responses.
+- Confirms UI search results are filtered for viewer roles when ACL denies read access.
+
+## Files
+- ecm-core/src/test/java/com/ecm/core/search/SearchAclFilteringTest.java
+- ecm-frontend/e2e/search-view.spec.ts

--- a/docs/VERIFICATION_DASHBOARD_20260106.md
+++ b/docs/VERIFICATION_DASHBOARD_20260106.md
@@ -38,6 +38,7 @@
 - Share link update validation: `docs/VERIFICATION_SHARE_LINK_UPDATE_ALLOWED_IP_VALIDATION_20260106.md`
 - Share link CIDR parsing: `docs/VERIFICATION_SHARE_LINK_CIDR_20260105.md`
 - Search ACL edge cases: `docs/VERIFICATION_SEARCH_ACL_EDGE_CASE_TESTS_20260106.md`
+- Search ACL regression coverage: `docs/VERIFICATION_SEARCH_ACL_REGRESSION_20260110.md`
 - Search pagination/deleted filter: `docs/VERIFICATION_SEARCH_PAGINATION_DELETED_TESTS_20260106.md`
 - Search disabled guards: `docs/VERIFICATION_SEARCH_DISABLED_GUARD_20260106.md`
 - Search available facets disabled: `docs/VERIFICATION_SEARCH_AVAILABLE_FACETS_DISABLED_20260106.md`

--- a/docs/VERIFICATION_INDEX_20251228.md
+++ b/docs/VERIFICATION_INDEX_20251228.md
@@ -104,6 +104,8 @@
   - Analytics storage-by-MIME payload
 - `docs/VERIFICATION_SEARCH_DISABLED_GUARD_20260106.md`
   - Search disabled guard paths in search services
+- `docs/VERIFICATION_SEARCH_ACL_REGRESSION_20260110.md`
+  - Search ACL regression coverage (backend + E2E)
 - `docs/VERIFICATION_SEARCH_AVAILABLE_FACETS_DISABLED_20260106.md`
   - Available facets guard when search is disabled
 - `docs/VERIFICATION_SEARCH_SUGGESTED_FILTERS_DISABLED_20260106.md`

--- a/docs/VERIFICATION_SEARCH_ACL_REGRESSION_20260110.md
+++ b/docs/VERIFICATION_SEARCH_ACL_REGRESSION_20260110.md
@@ -1,0 +1,7 @@
+# Verification: Search ACL Regression Coverage (2026-01-10)
+
+- `mvn test -Dtest=SearchAclFilteringTest`
+- Result: pass (18 tests)
+
+- `ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 npx playwright test e2e/search-view.spec.ts -g "Search results hide unauthorized documents for viewer" --project=chromium`
+- Result: pass


### PR DESCRIPTION
## Summary
- add backend ACL edge-case tests for full-text and facet filtering
- add viewer E2E scenario to confirm restricted docs are hidden
- add design/verification docs and update verification index

## Testing
- mvn test -Dtest=SearchAclFilteringTest
- ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 npx playwright test e2e/search-view.spec.ts -g "Search results hide unauthorized documents for viewer" --project=chromium