### PR TITLE
feat(frontend): enhance mail automation diagnostics UI

### DIFF
--- a/docs/PHASE11_MAIL_AUTOMATION_DEV.md
+++ b/docs/PHASE11_MAIL_AUTOMATION_DEV.md
@@ -1,0 +1,19 @@
+# Phase 11 - Mail Automation (UI) Enhancements
+
+## Summary
+- Added richer account telemetry: next poll countdown, retry-suggested indicator, and OAuth env prefix with copy shortcut.
+- Added diagnostics filter visibility with quick clear actions in Recent Mail Activity.
+- Resolved target folder IDs to readable paths/names in the Mail Rules table.
+- Added a smoke assertion for the new "Next poll" UI in Playwright.
+
+## Implementation Details
+- Accounts table now shows:
+  - `Next poll` status (overdue highlights in red).
+  - Retry suggestion chip when last fetch failed.
+  - OAuth env prefix with a copy-to-clipboard action.
+- Diagnostics section now exposes active filters as removable chips with a "Clear all" button.
+- Rules table resolves `assignFolderId` using `nodeService.getNode` and shows readable paths.
+
+## Files Changed
+- `ecm-frontend/src/pages/MailAutomationPage.tsx`
+- `ecm-frontend/e2e/mail-automation.spec.ts`

--- a/docs/PHASE11_MAIL_AUTOMATION_VERIFICATION.md
+++ b/docs/PHASE11_MAIL_AUTOMATION_VERIFICATION.md
@@ -1,0 +1,20 @@
+# Phase 11 - Mail Automation Verification
+
+## Environment
+- Date: 2026-02-02
+- UI: http://localhost:3000
+- API: http://localhost:7700
+- Auth bypass for E2E: `REACT_APP_E2E_BYPASS_AUTH=1`
+
+## Command
+```
+cd ecm-frontend
+ECM_UI_URL=http://localhost:3000 ECM_E2E_SKIP_LOGIN=1 npm run e2e -- mail-automation.spec.ts
+```
+
+## Result
+- ✅ Passed (2 tests)
+
+## Notes
+- Playwright login was bypassed using a token injected into localStorage; the frontend was started with `REACT_APP_E2E_BYPASS_AUTH=1`.
+- Artifacts are still stored under `ecm-frontend/test-results/` (playwright default).

--- a/ecm-frontend/src/index.tsx
+++ b/ecm-frontend/src/index.tsx
@@ -50,6 +50,26 @@ const renderApp = () => {
 
 const initAuth = async () => {
   try {
+    if (process.env.REACT_APP_E2E_BYPASS_AUTH === '1') {
+      let user = null;
+      let token = null;
+      try {
+        token = localStorage.getItem('token');
+        const rawUser = localStorage.getItem('user');
+        user = rawUser ? JSON.parse(rawUser) : null;
+      } catch {
+        user = null;
+      }
+      store.dispatch(
+        setSession({
+          user,
+          token,
+          isAuthenticated: Boolean(token),
+        })
+      );
+      renderApp();
+      return;
+    }
     const canUsePkce = !!(window.crypto && window.crypto.subtle);
     if (!canUsePkce) {
       console.warn('PKCE disabled: Web Crypto API is unavailable in this context.');


### PR DESCRIPTION
## Summary
- add next poll/overdue, retry suggested, and OAuth env prefix copy on mail accounts
- show active diagnostics filters with quick clear actions
- resolve rule target folders to readable paths
- add E2E auth bypass hooks and update mail automation spec

## Testing
- ECM_UI_URL=http://localhost:3000 ECM_E2E_SKIP_LOGIN=1 npm run e2e -- mail-automation.spec.ts