### PR TITLE
feat(frontend): add mail automation failure insights

### DIFF
--- a/docs/PHASE12_MAIL_AUTOMATION_ALERTS_DEV.md
+++ b/docs/PHASE12_MAIL_AUTOMATION_ALERTS_DEV.md
@@ -1,0 +1,17 @@
+# Phase 12 - Mail Automation Failure Insights
+
+## Summary
+- Added a failure insights panel to surface recent mail ingestion errors.
+- Visualized last-24-hour error trend and grouped top error reasons.
+- Highlighted impacted accounts to guide retry decisions.
+
+## Implementation Details
+- Aggregates error counts from recent diagnostics into 24 hourly buckets.
+- Groups top error reasons (first-line normalization) with counts.
+- Shows error rate, processed volume, and impacted account chips.
+- Trend bars scale to max bucket count for quick visual scan.
+
+## Files Changed
+- `ecm-frontend/src/pages/MailAutomationPage.tsx`
+- `ecm-frontend/e2e/mail-automation.spec.ts`
+

--- a/docs/PHASE12_MAIL_AUTOMATION_ALERTS_VERIFICATION.md
+++ b/docs/PHASE12_MAIL_AUTOMATION_ALERTS_VERIFICATION.md
@@ -1,0 +1,20 @@
+# Phase 12 - Mail Automation Failure Insights Verification
+
+## Environment
+- Date: 2026-02-02
+- UI: http://localhost:3000
+- API: http://localhost:7700
+- Auth bypass for E2E: `REACT_APP_E2E_BYPASS_AUTH=1`
+
+## Command
+```
+cd ecm-frontend
+ECM_UI_URL=http://localhost:3000 ECM_E2E_SKIP_LOGIN=1 npm run e2e -- mail-automation.spec.ts
+```
+
+## Result
+- ✅ Passed (2 tests)
+
+## Notes
+- Failure insights section is rendered within the Recent Mail Activity card.
+- Trend bars and top reasons derive from the last diagnostics sample window.

--- a/ecm-frontend/e2e/mail-automation.spec.ts
+++ b/ecm-frontend/e2e/mail-automation.spec.ts
@@ -101,6 +101,7 @@ test('Mail automation test connection and fetch summary', async ({ page, request
 
   const heading = page.getByRole('heading', { name: /mail automation/i });
   await expect(heading).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByText(/Failure Insights/i)).toBeVisible({ timeout: 30_000 });
   const accountName = accounts[0]?.name;
   if (accountName) {
     const escaped = accountName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');


### PR DESCRIPTION
## Summary
- add Failure Insights (last 24h) panel with error rate, top reasons, trend bars, and impacted accounts
- update mail automation E2E spec to validate the new insights section

## Testing
- ECM_UI_URL=http://localhost:3000 ECM_E2E_SKIP_LOGIN=1 npm run e2e -- mail-automation.spec.ts