### PR TITLE
feat: permission templates, search highlights, and custom fields

### DIFF
--- a/docs/PHASE46_PERMISSION_TEMPLATES_SEARCH_HIGHLIGHT_CUSTOM_FIELDS_DEV_20260204.md
+++ b/docs/PHASE46_PERMISSION_TEMPLATES_SEARCH_HIGHLIGHT_CUSTOM_FIELDS_DEV_20260204.md
@@ -1,0 +1,24 @@
+# PHASE46_PERMISSION_TEMPLATES_SEARCH_HIGHLIGHT_CUSTOM_FIELDS_DEV_20260204
+
+## Scope
+- Add admin-managed permission templates and apply them from the permissions dialog.
+- Enable search highlight snippets in backend search responses and surface them in UI.
+- Extend custom content type property types + validation.
+
+## Backend changes
+- Added `PermissionTemplate` entity with JSONB entries and CRUD + apply endpoints.
+- Added Liquibase changelog `027-add-permission-templates.xml` and included in master.
+- Added highlight query support in `FullTextSearchService` and `FacetedSearchService` with `<em>` tags.
+- Extended `ContentTypeService` validation for `integer`, `float`, `monetary`, `url`, `documentlink`, `long_text`.
+
+## Frontend changes
+- New admin page `PermissionTemplatesPage` with CRUD UI and authority autocomplete.
+- New API service `permissionTemplateService`.
+- Permissions dialog now supports selecting + applying templates with optional replace.
+- Admin menu and routes updated to include Permission Templates.
+- Search results and advanced search highlight fallback include description/content/textContent/extractedText/title/name.
+- Content types UI supports new property types and renders proper input controls in properties dialog.
+
+## Notes
+- Template apply uses `SecurityService.applyPermissionSet` per entry and respects replace flag.
+- Highlight implementation uses Spring Data Elasticsearch highlight query package.

--- a/docs/PHASE46_PERMISSION_TEMPLATES_SEARCH_HIGHLIGHT_CUSTOM_FIELDS_VERIFICATION_20260204.md
+++ b/docs/PHASE46_PERMISSION_TEMPLATES_SEARCH_HIGHLIGHT_CUSTOM_FIELDS_VERIFICATION_20260204.md
@@ -1,0 +1,13 @@
+# PHASE46_PERMISSION_TEMPLATES_SEARCH_HIGHLIGHT_CUSTOM_FIELDS_VERIFICATION_20260204
+
+## Build & deployment
+- `cd ecm-frontend && npm run build`
+- `docker compose up -d --build ecm-core ecm-frontend`
+
+## Automated verification (Playwright CLI)
+- `ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 ECM_E2E_SKIP_LOGIN=1 npx playwright test e2e/permission-templates.spec.ts`
+- `ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 ECM_E2E_SKIP_LOGIN=1 npx playwright test e2e/search-highlight.spec.ts`
+
+## Results
+- ✅ Permission template apply flow verified.
+- ✅ Search highlight snippets verified.

--- a/ecm-core/src/main/java/com/ecm/core/controller/PermissionTemplateController.java
+++ b/ecm-core/src/main/java/com/ecm/core/controller/PermissionTemplateController.java
@@ -1,0 +1,67 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.entity.PermissionTemplate;
+import com.ecm.core.service.PermissionTemplateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/security/permission-templates")
+@RequiredArgsConstructor
+@Tag(name = "Permission Templates", description = "Manage permission templates")
+public class PermissionTemplateController {
+
+    private final PermissionTemplateService permissionTemplateService;
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "List permission templates")
+    public ResponseEntity<List<PermissionTemplate>> listTemplates() {
+        return ResponseEntity.ok(permissionTemplateService.list());
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Create permission template")
+    public ResponseEntity<PermissionTemplate> createTemplate(@RequestBody PermissionTemplate template) {
+        return ResponseEntity.ok(permissionTemplateService.create(template));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Update permission template")
+    public ResponseEntity<PermissionTemplate> updateTemplate(
+        @Parameter(description = "Template ID") @PathVariable UUID id,
+        @RequestBody PermissionTemplate template) {
+        return ResponseEntity.ok(permissionTemplateService.update(id, template));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Delete permission template")
+    public ResponseEntity<Void> deleteTemplate(
+        @Parameter(description = "Template ID") @PathVariable UUID id) {
+        permissionTemplateService.delete(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/apply")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Apply permission template to node")
+    public ResponseEntity<Void> applyTemplate(
+        @Parameter(description = "Template ID") @PathVariable UUID id,
+        @Parameter(description = "Node ID") @RequestParam UUID nodeId,
+        @Parameter(description = "Replace existing permissions for listed principals")
+        @RequestParam(defaultValue = "false") boolean replace) {
+        permissionTemplateService.apply(id, nodeId, replace);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/ecm-core/src/main/java/com/ecm/core/entity/PermissionTemplate.java
+++ b/ecm-core/src/main/java/com/ecm/core/entity/PermissionTemplate.java
@@ -1,0 +1,39 @@
+package com.ecm.core.entity;
+
+import com.ecm.core.entity.Permission.AuthorityType;
+import com.vladmihalcea.hibernate.type.json.JsonType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.hibernate.annotations.Type;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reusable permission template applied to nodes.
+ */
+@Data
+@Entity
+@Table(name = "permission_templates")
+@EqualsAndHashCode(callSuper = true)
+public class PermissionTemplate extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    private String description;
+
+    @Type(JsonType.class)
+    @Column(columnDefinition = "jsonb")
+    private List<PermissionTemplateEntry> entries = new ArrayList<>();
+
+    @Data
+    public static class PermissionTemplateEntry {
+        private String authority;
+        private AuthorityType authorityType;
+        private PermissionSet permissionSet;
+    }
+}

--- a/ecm-core/src/main/java/com/ecm/core/repository/PermissionTemplateRepository.java
+++ b/ecm-core/src/main/java/com/ecm/core/repository/PermissionTemplateRepository.java
@@ -1,0 +1,12 @@
+package com.ecm.core.repository;
+
+import com.ecm.core.entity.PermissionTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PermissionTemplateRepository extends JpaRepository<PermissionTemplate, UUID> {
+    boolean existsByNameIgnoreCase(String name);
+    Optional<PermissionTemplate> findByNameIgnoreCase(String name);
+}

--- a/ecm-core/src/main/java/com/ecm/core/service/PermissionTemplateService.java
+++ b/ecm-core/src/main/java/com/ecm/core/service/PermissionTemplateService.java
@@ -1,0 +1,91 @@
+package com.ecm.core.service;
+
+import com.ecm.core.entity.Node;
+import com.ecm.core.entity.PermissionTemplate;
+import com.ecm.core.repository.PermissionTemplateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PermissionTemplateService {
+
+    private final PermissionTemplateRepository repository;
+    private final SecurityService securityService;
+    private final NodeService nodeService;
+
+    @Transactional(readOnly = true)
+    public List<PermissionTemplate> list() {
+        return repository.findAll();
+    }
+
+    public PermissionTemplate create(PermissionTemplate template) {
+        if (template.getName() == null || template.getName().isBlank()) {
+            throw new IllegalArgumentException("Template name is required");
+        }
+        if (repository.existsByNameIgnoreCase(template.getName())) {
+            throw new IllegalArgumentException("Template already exists: " + template.getName());
+        }
+        if (template.getEntries() == null) {
+            template.setEntries(List.of());
+        }
+        return repository.save(template);
+    }
+
+    public PermissionTemplate update(UUID id, PermissionTemplate updates) {
+        PermissionTemplate existing = repository.findById(id)
+            .orElseThrow(() -> new NoSuchElementException("Template not found: " + id));
+
+        if (updates.getName() != null && !updates.getName().isBlank()) {
+            if (!updates.getName().equalsIgnoreCase(existing.getName())
+                && repository.existsByNameIgnoreCase(updates.getName())) {
+                throw new IllegalArgumentException("Template already exists: " + updates.getName());
+            }
+            existing.setName(updates.getName());
+        }
+        if (updates.getDescription() != null) {
+            existing.setDescription(updates.getDescription());
+        }
+        if (updates.getEntries() != null) {
+            existing.setEntries(updates.getEntries());
+        }
+
+        return repository.save(existing);
+    }
+
+    public void delete(UUID id) {
+        repository.deleteById(id);
+    }
+
+    public void apply(UUID templateId, UUID nodeId, boolean replace) {
+        PermissionTemplate template = repository.findById(templateId)
+            .orElseThrow(() -> new NoSuchElementException("Template not found: " + templateId));
+        Node node = nodeService.getNode(nodeId);
+
+        if (template.getEntries() == null || template.getEntries().isEmpty()) {
+            return;
+        }
+
+        template.getEntries().forEach(entry -> {
+            if (entry == null || entry.getAuthority() == null || entry.getAuthority().isBlank()) {
+                return;
+            }
+            if (entry.getPermissionSet() == null || entry.getAuthorityType() == null) {
+                return;
+            }
+            securityService.applyPermissionSet(
+                node,
+                entry.getAuthority(),
+                entry.getAuthorityType(),
+                entry.getPermissionSet(),
+                replace
+            );
+        });
+    }
+}

--- a/ecm-core/src/main/resources/db/changelog/changes/027-add-permission-templates.xml
+++ b/ecm-core/src/main/resources/db/changelog/changes/027-add-permission-templates.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <changeSet id="027-add-permission-templates" author="codex">
+        <createTable tableName="permission_templates">
+            <column name="id" type="${uuid_type}">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="varchar(1000)"/>
+            <column name="entries" type="jsonb"/>
+            <column name="created_date" type="timestamp" defaultValueComputed="${now}">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_modified_date" type="timestamp"/>
+            <column name="created_by" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_modified_by" type="varchar(255)"/>
+            <column name="version" type="bigint"/>
+            <column name="is_deleted" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deleted_at" type="timestamp"/>
+            <column name="deleted_by" type="varchar(255)"/>
+        </createTable>
+
+        <createIndex indexName="idx_permission_templates_name" tableName="permission_templates" unique="true">
+            <column name="name"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/ecm-core/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/ecm-core/src/main/resources/db/changelog/db.changelog-master.xml
@@ -37,6 +37,7 @@
     <include file="db/changelog/changes/024-add-audit-category-settings.xml"/>
     <include file="db/changelog/changes/025-add-user-mfa-settings.xml"/>
     <include file="db/changelog/changes/026-add-webhook-subscriptions.xml"/>
+    <include file="db/changelog/changes/027-add-permission-templates.xml"/>
     <include file="db/changelog/changes/007-insert-initial-data.xml"/>
 
 </databaseChangeLog>

--- a/ecm-frontend/e2e/permission-templates.spec.ts
+++ b/ecm-frontend/e2e/permission-templates.spec.ts
@@ -1,0 +1,165 @@
+import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { fetchAccessToken, getRootFolderId, waitForApiReady } from './helpers/api';
+
+const baseApiUrl = process.env.ECM_API_URL || 'http://localhost:7700';
+const baseUiUrl = process.env.ECM_UI_URL || 'http://localhost:5500';
+const defaultUsername = process.env.ECM_E2E_USERNAME || 'admin';
+const defaultPassword = process.env.ECM_E2E_PASSWORD || 'admin';
+const viewerUsername = process.env.ECM_E2E_VIEWER_USERNAME || 'viewer';
+
+async function loginWithCredentials(page: Page, username: string, password: string, token?: string) {
+  if (process.env.ECM_E2E_SKIP_LOGIN === '1' && token) {
+    await page.addInitScript(
+      ({ authToken, authUser }) => {
+        window.localStorage.setItem('token', authToken);
+        window.localStorage.setItem('ecm_e2e_bypass', '1');
+        window.localStorage.setItem('user', JSON.stringify(authUser));
+      },
+      {
+        authToken: token,
+        authUser: {
+          id: `e2e-${username}`,
+          username,
+          email: `${username}@example.com`,
+          roles: ['ROLE_ADMIN'],
+        },
+      }
+    );
+    return;
+  }
+  const authPattern = /\/protocol\/openid-connect\/auth/;
+  const browsePattern = /\/browse\//;
+
+  await page.goto(`${baseUiUrl}/login`, { waitUntil: 'domcontentloaded' });
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await page.waitForURL(/(\/login$|\/browse\/|\/protocol\/openid-connect\/auth|login_required)/, { timeout: 60_000 });
+
+    if (page.url().endsWith('/login')) {
+      const keycloakButton = page.getByRole('button', { name: /sign in with keycloak/i });
+      try {
+        await keycloakButton.waitFor({ state: 'visible', timeout: 30_000 });
+        await keycloakButton.click();
+      } catch {
+        // retry
+      }
+      continue;
+    }
+
+    if (page.url().includes('login_required')) {
+      await page.goto(`${baseUiUrl}/login`, { waitUntil: 'domcontentloaded' });
+      continue;
+    }
+
+    if (authPattern.test(page.url())) {
+      await page.locator('#username').fill(username);
+      await page.locator('#password').fill(password);
+      await Promise.all([
+        page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+        page.locator('#kc-login').click(),
+      ]);
+    }
+
+    if (browsePattern.test(page.url())) {
+      break;
+    }
+  }
+
+  if (!browsePattern.test(page.url())) {
+    await page.goto(`${baseUiUrl}/browse/root`, { waitUntil: 'domcontentloaded' });
+  }
+
+  await page.waitForURL(browsePattern, { timeout: 60_000 });
+}
+
+async function createFolder(
+  request: APIRequestContext,
+  parentId: string,
+  name: string,
+  token: string,
+) {
+  const res = await request.post(`${baseApiUrl}/api/v1/folders`, {
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    data: { name, parentId, folderType: 'GENERAL', inheritPermissions: true },
+  });
+  expect(res.ok()).toBeTruthy();
+  const payload = (await res.json()) as { id?: string };
+  if (!payload.id) {
+    throw new Error('Folder creation did not return id');
+  }
+  return payload.id;
+}
+
+async function createPermissionTemplate(
+  request: APIRequestContext,
+  token: string,
+  name: string,
+  authority: string,
+) {
+  const res = await request.post(`${baseApiUrl}/api/v1/security/permission-templates`, {
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    data: {
+      name,
+      description: 'E2E permission template',
+      entries: [
+        {
+          authority,
+          authorityType: 'USER',
+          permissionSet: 'CONSUMER',
+        },
+      ],
+    },
+  });
+  expect(res.ok()).toBeTruthy();
+  const payload = (await res.json()) as { id?: string };
+  if (!payload.id) {
+    throw new Error('Template creation did not return id');
+  }
+  return payload.id;
+}
+
+test('Admin can apply permission template from permissions dialog', async ({ page, request }) => {
+  test.setTimeout(240_000);
+
+  await waitForApiReady(request, { apiUrl: baseApiUrl });
+
+  const token = await fetchAccessToken(request, defaultUsername, defaultPassword);
+  const rootId = await getRootFolderId(request, token, { apiUrl: baseApiUrl });
+  const parentName = `e2e-template-parent-${Date.now()}`;
+  const parentId = await createFolder(request, rootId, parentName, token);
+  const folderName = `e2e-template-child-${Date.now()}`;
+  const folderId = await createFolder(request, parentId, folderName, token);
+
+  const templateName = `e2e-template-${Date.now()}`;
+  const templateId = await createPermissionTemplate(request, token, templateName, viewerUsername);
+
+  await loginWithCredentials(page, defaultUsername, defaultPassword, token);
+  await page.goto(`${baseUiUrl}/browse/${parentId}`, { waitUntil: 'domcontentloaded' });
+  await page.getByRole('button', { name: 'list view' }).click();
+
+  const row = page.getByRole('row', { name: new RegExp(folderName) });
+  await expect(row).toBeVisible({ timeout: 60_000 });
+  await row.getByRole('button', { name: `Actions for ${folderName}` }).click();
+  await page.getByRole('menuitem', { name: 'Permissions' }).click();
+
+  const dialog = page.getByRole('dialog').filter({ hasText: 'Manage Permissions' });
+  await expect(dialog).toBeVisible({ timeout: 60_000 });
+
+  const templateSelect = dialog.getByLabel('Template');
+  await templateSelect.click();
+  await page.getByRole('option', { name: new RegExp(templateName) }).click();
+  await dialog.getByRole('button', { name: 'Apply Template' }).click();
+
+  const viewerRow = dialog.getByRole('row', { name: new RegExp(viewerUsername) });
+  await expect(viewerRow).toBeVisible({ timeout: 60_000 });
+
+  await dialog.getByRole('button', { name: /^Close$/ }).click();
+
+  await request.delete(`${baseApiUrl}/api/v1/security/permission-templates/${templateId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  }).catch(() => null);
+
+  await request.delete(`${baseApiUrl}/api/v1/nodes/${parentId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  }).catch(() => null);
+});

--- a/ecm-frontend/e2e/search-highlight.spec.ts
+++ b/ecm-frontend/e2e/search-highlight.spec.ts
@@ -1,0 +1,191 @@
+import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import {
+  fetchAccessToken,
+  findChildFolderId,
+  getRootFolderId,
+  reindexByQuery,
+  waitForApiReady,
+  waitForSearchIndex,
+} from './helpers/api';
+
+const baseApiUrl = process.env.ECM_API_URL || 'http://localhost:7700';
+const baseUiUrl = process.env.ECM_UI_URL || 'http://localhost:5500';
+const defaultUsername = process.env.ECM_E2E_USERNAME || 'admin';
+const defaultPassword = process.env.ECM_E2E_PASSWORD || 'admin';
+
+async function loginWithCredentials(page: Page, username: string, password: string, token?: string) {
+  if (process.env.ECM_E2E_SKIP_LOGIN === '1' && token) {
+    await page.addInitScript(
+      ({ authToken, authUser }) => {
+        window.localStorage.setItem('token', authToken);
+        window.localStorage.setItem('ecm_e2e_bypass', '1');
+        window.localStorage.setItem('user', JSON.stringify(authUser));
+      },
+      {
+        authToken: token,
+        authUser: {
+          id: `e2e-${username}`,
+          username,
+          email: `${username}@example.com`,
+          roles: ['ROLE_ADMIN'],
+        },
+      }
+    );
+    return;
+  }
+  const authPattern = /\/protocol\/openid-connect\/auth/;
+  const browsePattern = /\/browse\//;
+
+  await page.goto(`${baseUiUrl}/login`, { waitUntil: 'domcontentloaded' });
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await page.waitForURL(/(\/login$|\/browse\/|\/protocol\/openid-connect\/auth|login_required)/, { timeout: 60_000 });
+
+    if (page.url().endsWith('/login')) {
+      const keycloakButton = page.getByRole('button', { name: /sign in with keycloak/i });
+      try {
+        await keycloakButton.waitFor({ state: 'visible', timeout: 30_000 });
+        await keycloakButton.click();
+      } catch {
+        // retry
+      }
+      continue;
+    }
+
+    if (page.url().includes('login_required')) {
+      await page.goto(`${baseUiUrl}/login`, { waitUntil: 'domcontentloaded' });
+      continue;
+    }
+
+    if (authPattern.test(page.url())) {
+      await page.locator('#username').fill(username);
+      await page.locator('#password').fill(password);
+      await Promise.all([
+        page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+        page.locator('#kc-login').click(),
+      ]);
+    }
+
+    if (browsePattern.test(page.url())) {
+      break;
+    }
+  }
+
+  if (!browsePattern.test(page.url())) {
+    await page.goto(`${baseUiUrl}/browse/root`, { waitUntil: 'domcontentloaded' });
+  }
+
+  await page.waitForURL(browsePattern, { timeout: 60_000 });
+}
+
+async function createFolder(
+  request: APIRequestContext,
+  parentId: string,
+  name: string,
+  token: string,
+) {
+  const res = await request.post(`${baseApiUrl}/api/v1/folders`, {
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    data: { name, parentId, folderType: 'GENERAL', inheritPermissions: true },
+  });
+  expect(res.ok()).toBeTruthy();
+  const payload = (await res.json()) as { id?: string };
+  if (!payload.id) {
+    throw new Error('Folder creation did not return id');
+  }
+  return payload.id;
+}
+
+async function uploadDocument(
+  request: APIRequestContext,
+  folderId: string,
+  filename: string,
+  token: string,
+  content: string,
+) {
+  const uploadRes = await request.post(
+    `${baseApiUrl}/api/v1/documents/upload?folderId=${folderId}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      multipart: {
+        file: {
+          name: filename,
+          mimeType: 'text/plain',
+          buffer: Buffer.from(content),
+        },
+      },
+    },
+  );
+  expect(uploadRes.ok()).toBeTruthy();
+  const uploadJson = (await uploadRes.json()) as { documentId?: string; id?: string };
+  const documentId = uploadJson.documentId ?? uploadJson.id;
+  if (!documentId) {
+    throw new Error('Upload did not return document id');
+  }
+  return documentId;
+}
+
+async function isSearchAvailable(request: APIRequestContext, token: string) {
+  try {
+    const res = await request.get(`${baseApiUrl}/api/v1/system/status`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok()) {
+      return false;
+    }
+    const payload = (await res.json()) as { search?: { error?: string; searchEnabled?: boolean } };
+    const search = payload.search;
+    if (!search) {
+      return false;
+    }
+    if (search.searchEnabled === false) {
+      return false;
+    }
+    return !search.error;
+  } catch {
+    return false;
+  }
+}
+
+test('Search results include highlight snippets', async ({ page, request }) => {
+  test.setTimeout(240_000);
+
+  await waitForApiReady(request, { apiUrl: baseApiUrl });
+  const token = await fetchAccessToken(request, defaultUsername, defaultPassword);
+  const searchAvailable = await isSearchAvailable(request, token);
+  test.skip(!searchAvailable, 'Search is disabled');
+
+  const rootId = await getRootFolderId(request, token, { apiUrl: baseApiUrl });
+  const documentsId = await findChildFolderId(request, rootId, 'Documents', token, { apiUrl: baseApiUrl });
+
+  const folderName = `e2e-highlight-${Date.now()}`;
+  const folderId = await createFolder(request, documentsId, folderName, token);
+
+  const highlightTerm = `highlight${Date.now()}`;
+  const filename = `${highlightTerm}.txt`;
+  await uploadDocument(
+    request,
+    folderId,
+    filename,
+    token,
+    `This is a ${highlightTerm} test document used for e2e highlighting.\n${highlightTerm} appears twice.`,
+  );
+
+  await reindexByQuery(request, filename, token, { apiUrl: baseApiUrl, limit: 5, refresh: true });
+  await waitForSearchIndex(request, filename, token, { apiUrl: baseApiUrl, maxAttempts: 60 });
+
+  await loginWithCredentials(page, defaultUsername, defaultPassword, token);
+  await page.goto(`${baseUiUrl}/search-results`, { waitUntil: 'domcontentloaded' });
+
+  const quickSearchInput = page.getByPlaceholder('Quick search by name...');
+  await quickSearchInput.fill(highlightTerm);
+  await quickSearchInput.press('Enter');
+
+  const resultCard = page.locator('.MuiCard-root').filter({ hasText: filename }).first();
+  await expect(resultCard).toBeVisible({ timeout: 60_000 });
+  await expect(resultCard.locator('em').first()).toBeVisible({ timeout: 60_000 });
+
+  await request.delete(`${baseApiUrl}/api/v1/nodes/${folderId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  }).catch(() => null);
+});

--- a/ecm-frontend/src/App.tsx
+++ b/ecm-frontend/src/App.tsx
@@ -15,6 +15,7 @@ import AdminDashboard from './pages/AdminDashboard';
 import MailAutomationPage from './pages/MailAutomationPage';
 import ContentTypesPage from './pages/ContentTypesPage';
 import WebhookSubscriptionsPage from './pages/WebhookSubscriptionsPage';
+import PermissionTemplatesPage from './pages/PermissionTemplatesPage';
 import EditorPage from './pages/EditorPage';
 import TasksPage from './pages/TasksPage';
 import AdvancedSearchPage from './pages/AdvancedSearchPage';
@@ -198,6 +199,16 @@ const App: React.FC = () => {
                 <PrivateRoute requiredRoles={['ROLE_ADMIN']}>
                   <MainLayout>
                     <ContentTypesPage />
+                  </MainLayout>
+                </PrivateRoute>
+              }
+            />
+            <Route
+              path="/admin/permission-templates"
+              element={
+                <PrivateRoute requiredRoles={['ROLE_ADMIN']}>
+                  <MainLayout>
+                    <PermissionTemplatesPage />
                   </MainLayout>
                 </PrivateRoute>
               }

--- a/ecm-frontend/src/components/dialogs/PropertiesDialog.tsx
+++ b/ecm-frontend/src/components/dialogs/PropertiesDialog.tsx
@@ -342,7 +342,7 @@ const PropertiesDialog: React.FC = () => {
       );
     }
 
-    if (prop.type === 'list' && prop.options && prop.options.length > 0) {
+    if ((prop.type === 'list' || prop.type === 'select') && prop.options && prop.options.length > 0) {
       return (
         <FormControl size="small" fullWidth disabled={disabled}>
           <InputLabel id={selectLabelId}>{label}</InputLabel>
@@ -368,8 +368,18 @@ const PropertiesDialog: React.FC = () => {
     }
 
     const resolvedValue = prop.type === 'date' ? normalizeDateValue(value) : value;
-    const inputType =
-      prop.type === 'number' ? 'number' : prop.type === 'date' ? 'date' : 'text';
+    const isNumber =
+      prop.type === 'number' || prop.type === 'integer' || prop.type === 'float' || prop.type === 'monetary';
+    const inputType = prop.type === 'date'
+      ? 'date'
+      : prop.type === 'url'
+        ? 'url'
+        : isNumber
+          ? 'number'
+          : 'text';
+    const step = prop.type === 'integer' ? 1 : prop.type === 'monetary' ? 0.01 : isNumber ? 'any' : undefined;
+    const multiline = prop.type === 'long_text';
+    const placeholder = prop.type === 'documentlink' ? 'Document ID or path' : undefined;
 
     return (
       <TextField
@@ -380,6 +390,10 @@ const PropertiesDialog: React.FC = () => {
         fullWidth
         disabled={disabled}
         type={inputType}
+        inputProps={step ? { step } : undefined}
+        multiline={multiline}
+        minRows={multiline ? 3 : undefined}
+        placeholder={placeholder}
         InputLabelProps={prop.type === 'date' ? { shrink: true } : undefined}
         required={prop.required}
       />

--- a/ecm-frontend/src/components/layout/MainLayout.menu.test.tsx
+++ b/ecm-frontend/src/components/layout/MainLayout.menu.test.tsx
@@ -71,6 +71,7 @@ test('account menu shows Tags/Categories for admin/editor roles', async () => {
   expect(screen.getByRole('menuitem', { name: 'Admin Dashboard' })).toBeTruthy();
   expect(screen.getByRole('menuitem', { name: 'Mail Automation' })).toBeTruthy();
   expect(screen.getByRole('menuitem', { name: 'Content Types' })).toBeTruthy();
+  expect(screen.getByRole('menuitem', { name: 'Permission Templates' })).toBeTruthy();
   expect(screen.getByRole('menuitem', { name: 'Webhooks' })).toBeTruthy();
   expect(screen.getByRole('menuitem', { name: 'System Status' })).toBeTruthy();
 });
@@ -90,6 +91,7 @@ test('account menu hides Tags/Categories for viewer role', async () => {
   expect(screen.queryByRole('menuitem', { name: 'Admin Dashboard' })).toBeNull();
   expect(screen.queryByRole('menuitem', { name: 'Mail Automation' })).toBeNull();
   expect(screen.queryByRole('menuitem', { name: 'Content Types' })).toBeNull();
+  expect(screen.queryByRole('menuitem', { name: 'Permission Templates' })).toBeNull();
   expect(screen.queryByRole('menuitem', { name: 'Webhooks' })).toBeNull();
   expect(screen.queryByRole('menuitem', { name: 'System Status' })).toBeNull();
 });

--- a/ecm-frontend/src/components/layout/MainLayout.tsx
+++ b/ecm-frontend/src/components/layout/MainLayout.tsx
@@ -35,6 +35,7 @@ import {
   MailOutline,
   Description,
   Link as LinkIcon,
+  AdminPanelSettings,
   PushPin,
   PushPinOutlined,
 } from '@mui/icons-material';
@@ -358,6 +359,12 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
                     <Description fontSize="small" />
                   </ListItemIcon>
                   <ListItemText>Content Types</ListItemText>
+                </MenuItem>
+                <MenuItem onClick={() => navigate('/admin/permission-templates')}>
+                  <ListItemIcon>
+                    <AdminPanelSettings fontSize="small" />
+                  </ListItemIcon>
+                  <ListItemText>Permission Templates</ListItemText>
                 </MenuItem>
                 <MenuItem onClick={() => navigate('/admin/webhooks')}>
                   <ListItemIcon>

--- a/ecm-frontend/src/pages/AdvancedSearchPage.tsx
+++ b/ecm-frontend/src/pages/AdvancedSearchPage.tsx
@@ -397,14 +397,25 @@ const AdvancedSearchPage: React.FC = () => {
                     </Box>
                     
                     {/* Snippets / Highlights */}
-                    {result.highlights?.content && (
-                        <Typography 
-                            variant="body2" 
-                            color="textSecondary" 
-                            sx={{ mt: 1 }}
-                            dangerouslySetInnerHTML={{ __html: '...' + result.highlights.content[0] + '...' }} 
+                    {(() => {
+                      const snippet = result.highlights?.description?.[0]
+                        || result.highlights?.content?.[0]
+                        || result.highlights?.textContent?.[0]
+                        || result.highlights?.extractedText?.[0]
+                        || result.highlights?.title?.[0]
+                        || result.highlights?.name?.[0];
+                      if (!snippet) {
+                        return null;
+                      }
+                      return (
+                        <Typography
+                          variant="body2"
+                          color="textSecondary"
+                          sx={{ mt: 1 }}
+                          dangerouslySetInnerHTML={{ __html: `...${snippet}...` }}
                         />
-                    )}
+                      );
+                    })()}
                     
                     <Box mt={1} display="flex" gap={1}>
                         <Chip label={result.mimeType} size="small" variant="outlined" />

--- a/ecm-frontend/src/pages/ContentTypesPage.tsx
+++ b/ecm-frontend/src/pages/ContentTypesPage.tsx
@@ -31,7 +31,35 @@ import contentTypeService, {
   ContentTypePropertyType,
 } from 'services/contentTypeService';
 
-const PROPERTY_TYPES: ContentTypePropertyType[] = ['text', 'number', 'date', 'boolean', 'list'];
+const PROPERTY_TYPES: ContentTypePropertyType[] = [
+  'text',
+  'long_text',
+  'url',
+  'integer',
+  'float',
+  'monetary',
+  'number',
+  'date',
+  'boolean',
+  'list',
+  'select',
+  'documentlink',
+];
+
+const PROPERTY_TYPE_LABELS: Record<ContentTypePropertyType, string> = {
+  text: 'Text',
+  long_text: 'Long Text',
+  url: 'URL',
+  integer: 'Integer',
+  float: 'Float',
+  monetary: 'Monetary',
+  number: 'Number',
+  date: 'Date',
+  boolean: 'Boolean',
+  list: 'List',
+  select: 'Select',
+  documentlink: 'Document Link',
+};
 
 const emptyProperty = (): ContentTypePropertyDefinition => ({
   name: '',
@@ -332,7 +360,9 @@ const ContentTypesPage: React.FC = () => {
                         onChange={(event) => updateProperty(index, { type: event.target.value as ContentTypePropertyType })}
                       >
                         {PROPERTY_TYPES.map((type) => (
-                          <MenuItem key={type} value={type}>{type}</MenuItem>
+                          <MenuItem key={type} value={type}>
+                            {PROPERTY_TYPE_LABELS[type] ?? type}
+                          </MenuItem>
                         ))}
                       </Select>
                     </Grid>

--- a/ecm-frontend/src/pages/PermissionTemplatesPage.tsx
+++ b/ecm-frontend/src/pages/PermissionTemplatesPage.tsx
@@ -1,0 +1,330 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+  Autocomplete,
+  Chip,
+} from '@mui/material';
+import { Add, Delete, Edit } from '@mui/icons-material';
+import { toast } from 'react-toastify';
+import nodeService, { PermissionSetMetadata } from 'services/nodeService';
+import permissionTemplateService, {
+  PermissionTemplate,
+  PermissionTemplateEntry,
+} from 'services/permissionTemplateService';
+import userGroupService from 'services/userGroupService';
+
+const emptyEntry = (permissionSet: string): PermissionTemplateEntry => ({
+  authority: '',
+  authorityType: 'USER',
+  permissionSet,
+});
+
+const PermissionTemplatesPage: React.FC = () => {
+  const [templates, setTemplates] = useState<PermissionTemplate[]>([]);
+  const [permissionSets, setPermissionSets] = useState<PermissionSetMetadata[]>([]);
+  const [users, setUsers] = useState<string[]>([]);
+  const [groups, setGroups] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState<PermissionTemplate | null>(null);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [entries, setEntries] = useState<PermissionTemplateEntry[]>([]);
+
+  const permissionSetOptions = useMemo(() => {
+    return [...permissionSets].sort((a, b) => {
+      const left = a.order ?? 0;
+      const right = b.order ?? 0;
+      if (left !== right) {
+        return left - right;
+      }
+      return a.name.localeCompare(b.name);
+    });
+  }, [permissionSets]);
+
+  const loadTemplates = async () => {
+    try {
+      setLoading(true);
+      const data = await permissionTemplateService.list();
+      setTemplates(data ?? []);
+    } catch {
+      toast.error('Failed to load permission templates');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadOptions = async () => {
+    try {
+      const [meta, usersList, groupList] = await Promise.all([
+        nodeService.getPermissionSetMetadata().catch(() => []),
+        userGroupService.listUsers().catch(() => []),
+        userGroupService.listGroups().catch(() => []),
+      ]);
+      setPermissionSets(meta ?? []);
+      setUsers(usersList.map((u) => u.username));
+      setGroups(groupList.map((g) => g.name));
+    } catch {
+      // optional
+    }
+  };
+
+  useEffect(() => {
+    loadOptions();
+    loadTemplates();
+  }, []);
+
+  const openCreateDialog = () => {
+    setEditingTemplate(null);
+    setName('');
+    setDescription('');
+    const defaultSet = permissionSetOptions[0]?.name ?? 'CONSUMER';
+    setEntries([emptyEntry(defaultSet)]);
+    setDialogOpen(true);
+  };
+
+  const openEditDialog = (template: PermissionTemplate) => {
+    setEditingTemplate(template);
+    setName(template.name ?? '');
+    setDescription(template.description ?? '');
+    setEntries(template.entries ?? []);
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      toast.error('Template name is required');
+      return;
+    }
+    const cleanedEntries = entries
+      .map((entry) => ({
+        ...entry,
+        authority: entry.authority.trim(),
+        permissionSet: entry.permissionSet,
+      }))
+      .filter((entry) => entry.authority && entry.permissionSet);
+
+    if (cleanedEntries.length === 0) {
+      toast.error('Add at least one permission entry');
+      return;
+    }
+
+    try {
+      if (editingTemplate) {
+        await permissionTemplateService.update(editingTemplate.id, {
+          name: name.trim(),
+          description: description.trim() || undefined,
+          entries: cleanedEntries,
+        });
+        toast.success('Permission template updated');
+      } else {
+        await permissionTemplateService.create({
+          name: name.trim(),
+          description: description.trim() || undefined,
+          entries: cleanedEntries,
+        });
+        toast.success('Permission template created');
+      }
+      setDialogOpen(false);
+      await loadTemplates();
+    } catch {
+      toast.error('Failed to save permission template');
+    }
+  };
+
+  const handleDelete = async (template: PermissionTemplate) => {
+    if (!window.confirm(`Delete permission template "${template.name}"?`)) {
+      return;
+    }
+    try {
+      await permissionTemplateService.remove(template.id);
+      toast.success('Permission template deleted');
+      await loadTemplates();
+    } catch {
+      toast.error('Failed to delete permission template');
+    }
+  };
+
+  const updateEntry = (index: number, updates: Partial<PermissionTemplateEntry>) => {
+    setEntries((prev) => prev.map((entry, i) => (i === index ? { ...entry, ...updates } : entry)));
+  };
+
+  const addEntry = () => {
+    const defaultSet = permissionSetOptions[0]?.name ?? 'CONSUMER';
+    setEntries((prev) => [...prev, emptyEntry(defaultSet)]);
+  };
+
+  const removeEntry = (index: number) => {
+    setEntries((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  return (
+    <Box maxWidth={1100}>
+      <Box display="flex" alignItems="center" justifyContent="space-between" mb={2}>
+        <Box>
+          <Typography variant="h5">Permission Templates</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Reusable ACL presets for users and groups.
+          </Typography>
+        </Box>
+        <Button variant="contained" startIcon={<Add />} onClick={openCreateDialog}>
+          New Template
+        </Button>
+      </Box>
+
+      <Paper variant="outlined">
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Description</TableCell>
+              <TableCell>Entries</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {templates.map((template) => (
+              <TableRow key={template.id} hover>
+                <TableCell>{template.name}</TableCell>
+                <TableCell>{template.description || '—'}</TableCell>
+                <TableCell>
+                  <Box display="flex" flexWrap="wrap" gap={0.5}>
+                    {(template.entries || []).map((entry, idx) => (
+                      <Chip
+                        key={`${template.id}-${idx}`}
+                        size="small"
+                        label={`${entry.authority} · ${entry.permissionSet}`}
+                        variant="outlined"
+                      />
+                    ))}
+                    {(template.entries || []).length === 0 && (
+                      <Typography variant="caption" color="text.secondary">No entries</Typography>
+                    )}
+                  </Box>
+                </TableCell>
+                <TableCell align="right">
+                  <IconButton size="small" onClick={() => openEditDialog(template)}>
+                    <Edit fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" color="error" onClick={() => handleDelete(template)}>
+                    <Delete fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+            {!loading && templates.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={4}>
+                  <Typography variant="body2" color="text.secondary">
+                    No permission templates defined.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </Paper>
+
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="md" fullWidth>
+        <DialogTitle>{editingTemplate ? 'Edit Permission Template' : 'New Permission Template'}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              fullWidth
+            />
+            <TextField
+              label="Description"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              fullWidth
+            />
+            <Divider />
+            <Typography variant="subtitle2">Entries</Typography>
+            <Stack spacing={2}>
+              {entries.map((entry, index) => (
+                <Paper key={`entry-${index}`} variant="outlined" sx={{ p: 2 }}>
+                  <Stack spacing={2} direction={{ xs: 'column', md: 'row' }} alignItems="center">
+                    <FormControl size="small" sx={{ minWidth: 140 }}>
+                      <InputLabel id={`entry-type-${index}`}>Type</InputLabel>
+                      <Select
+                        labelId={`entry-type-${index}`}
+                        label="Type"
+                        value={entry.authorityType}
+                        onChange={(event) => updateEntry(index, { authorityType: event.target.value as 'USER' | 'GROUP' })}
+                      >
+                        <MenuItem value="USER">User</MenuItem>
+                        <MenuItem value="GROUP">Group</MenuItem>
+                      </Select>
+                    </FormControl>
+                    <Autocomplete
+                      freeSolo
+                      options={entry.authorityType === 'GROUP' ? groups : users}
+                      value={entry.authority}
+                      onInputChange={(_, value) => updateEntry(index, { authority: value })}
+                      renderInput={(params) => (
+                        <TextField {...params} label="Authority" size="small" fullWidth />
+                      )}
+                      sx={{ flex: 1 }}
+                    />
+                    <FormControl size="small" sx={{ minWidth: 200 }}>
+                      <InputLabel id={`entry-set-${index}`}>Permission Set</InputLabel>
+                      <Select
+                        labelId={`entry-set-${index}`}
+                        label="Permission Set"
+                        value={entry.permissionSet}
+                        onChange={(event) => updateEntry(index, { permissionSet: String(event.target.value) })}
+                      >
+                        {permissionSetOptions.map((option) => (
+                          <MenuItem key={option.name} value={option.name}>
+                            {option.label || option.name}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <IconButton size="small" color="error" onClick={() => removeEntry(index)}>
+                      <Delete fontSize="small" />
+                    </IconButton>
+                  </Stack>
+                </Paper>
+              ))}
+            </Stack>
+            <Button variant="outlined" startIcon={<Add />} onClick={addEntry}>
+              Add Entry
+            </Button>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={handleSave}>
+            {editingTemplate ? 'Save Changes' : 'Create Template'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default PermissionTemplatesPage;

--- a/ecm-frontend/src/pages/SearchResults.tsx
+++ b/ecm-frontend/src/pages/SearchResults.tsx
@@ -1649,7 +1649,14 @@ const SearchResults: React.FC = () => {
                         </Typography>
                         <Highlight
                           text={node.description}
-                          highlights={node.highlights?.description || node.highlights?.content}
+                          highlights={
+                            node.highlights?.description
+                            || node.highlights?.content
+                            || node.highlights?.textContent
+                            || node.highlights?.extractedText
+                            || node.highlights?.title
+                            || node.highlights?.name
+                          }
                         />
                         {renderTagsCategories(node)}
                         <Box mt={2}>

--- a/ecm-frontend/src/services/contentTypeService.ts
+++ b/ecm-frontend/src/services/contentTypeService.ts
@@ -1,6 +1,18 @@
 import api from './api';
 
-export type ContentTypePropertyType = 'text' | 'number' | 'date' | 'boolean' | 'list';
+export type ContentTypePropertyType =
+  | 'text'
+  | 'long_text'
+  | 'number'
+  | 'integer'
+  | 'float'
+  | 'monetary'
+  | 'date'
+  | 'boolean'
+  | 'list'
+  | 'select'
+  | 'url'
+  | 'documentlink';
 
 export interface ContentTypePropertyDefinition {
   name: string;

--- a/ecm-frontend/src/services/permissionTemplateService.ts
+++ b/ecm-frontend/src/services/permissionTemplateService.ts
@@ -1,0 +1,55 @@
+import api from './api';
+
+export type PermissionTemplateEntry = {
+  authority: string;
+  authorityType: 'USER' | 'GROUP';
+  permissionSet: string;
+};
+
+export interface PermissionTemplate {
+  id: string;
+  name: string;
+  description?: string;
+  entries: PermissionTemplateEntry[];
+  createdBy?: string;
+  createdDate?: string;
+}
+
+export interface PermissionTemplateCreateRequest {
+  name: string;
+  description?: string;
+  entries: PermissionTemplateEntry[];
+}
+
+export interface PermissionTemplateUpdateRequest {
+  name?: string;
+  description?: string;
+  entries?: PermissionTemplateEntry[];
+}
+
+class PermissionTemplateService {
+  async list(): Promise<PermissionTemplate[]> {
+    return api.get<PermissionTemplate[]>('/security/permission-templates');
+  }
+
+  async create(payload: PermissionTemplateCreateRequest): Promise<PermissionTemplate> {
+    return api.post<PermissionTemplate>('/security/permission-templates', payload);
+  }
+
+  async update(id: string, payload: PermissionTemplateUpdateRequest): Promise<PermissionTemplate> {
+    return api.put<PermissionTemplate>(`/security/permission-templates/${id}`, payload);
+  }
+
+  async remove(id: string): Promise<void> {
+    return api.delete(`/security/permission-templates/${id}`);
+  }
+
+  async apply(id: string, nodeId: string, replace = false): Promise<void> {
+    return api.post(`/security/permission-templates/${id}/apply`, null, {
+      params: { nodeId, replace },
+    });
+  }
+}
+
+const permissionTemplateService = new PermissionTemplateService();
+export default permissionTemplateService;


### PR DESCRIPTION
## Summary
- add permission templates (backend CRUD + admin UI + apply flow)
- add search highlight snippets (Elasticsearch highlight + UI fallback)
- extend content type property types + validation
- add Playwright coverage for permission templates and search highlight

## Testing
- cd ecm-frontend && npm run build
- ECM_E2E_SKIP_LOGIN=1 ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 npx playwright test
- ECM_E2E_SKIP_LOGIN=1 ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 npx playwright test e2e/permission-templates.spec.ts e2e/search-highlight.spec.ts
- cd ecm-core && mvn test
- cd ecm-frontend && npm run lint