### PR TITLE
fix(preview): limit retries to transient failures

### DIFF
--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -14,6 +14,8 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
 - Phase 3 commit split: `docs/PHASE3_COMMIT_SPLIT_PLAN_20260213.md`
 - Phase 3 release notes: `docs/RELEASE_NOTES_20260213_PHASE3.md`
 - Phase 3 delivery report (single file): `docs/PHASE3_DELIVERY_REPORT_20260213.md`
+- Phase 4 plan: `docs/NEXT_7DAY_PLAN_PHASE4_20260213.md`
+- Phase 4 D1: Preview retry classification hardening: `docs/PHASE4_D1_PREVIEW_RETRY_CLASSIFICATION_20260213.md`
 
 ## OCR (Phase 3)
 

--- a/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
@@ -1,0 +1,121 @@
+# Next 7-Day Plan - Phase 4 (Preview Hardening + Reliability) - 2026-02-13
+
+This plan focuses on preview generation reliability, retry correctness, and UI/operator ergonomics for failure handling.
+
+## Guiding Principles
+
+- Prefer "safe by default": avoid infinite or wasteful retries for permanent failures.
+- Keep the UX consistent: Search/Advanced Search/Preview dialog should agree on status semantics.
+- Verify every slice with automation (backend tests + Playwright E2E gate subset).
+
+## Day 1 (Done): Retry Classification Hardening
+
+Goal:
+
+- Stop auto-retrying permanent preview failures (for example malformed PDFs).
+- Treat CAD preview disabled/unconfigured as UNSUPPORTED (not FAILED).
+
+Deliverables:
+
+- Implementation + tests
+- Design/verification doc:
+  - `docs/PHASE4_D1_PREVIEW_RETRY_CLASSIFICATION_20260213.md`
+
+Verification:
+
+- `cd ecm-core && mvn -q test`
+- `cd ecm-frontend && ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 npx playwright test e2e/ocr-queue-ui.spec.ts e2e/pdf-preview.spec.ts e2e/search-preview-status.spec.ts --project=chromium`
+
+## Day 2: MIME Type Normalization for `application/octet-stream`
+
+Goal:
+
+- Reduce false UNSUPPORTED previews when uploads are mislabeled as `application/octet-stream`.
+
+Scope:
+
+- Add server-side MIME normalization on upload (extension and/or magic bytes for common formats):
+  - PDF (`%PDF-`)
+  - PNG/JPEG
+  - Plain text (UTF-8 heuristic) - optional
+
+Acceptance:
+
+- When a PDF is uploaded with `application/octet-stream` but `.pdf` name or PDF magic bytes, it is stored as `application/pdf` and preview succeeds.
+- No regression for truly unknown binaries.
+
+Verification:
+
+- Unit tests for MIME sniffing.
+- Playwright: upload mislabeled PDF and verify preview READY.
+
+## Day 3: Preview Failure Taxonomy + UX Messaging
+
+Goal:
+
+- Make failure category actionable:
+  - TEMPORARY: retry makes sense
+  - PERMANENT: retry unlikely, guide to replace/check file
+  - UNSUPPORTED: no retry actions, guide to download/convert
+
+Scope:
+
+- Add/extend a small, curated set of "permanent" PDF parse error hints.
+- UI copy updates for PERMANENT failures.
+
+Acceptance:
+
+- Search/Advanced Search show consistent chips and consistent action availability.
+
+## Day 4: Bulk Actions Guardrails
+
+Goal:
+
+- Bulk retry should only target TEMPORARY failures, not PERMANENT.
+
+Scope:
+
+- Backend: optional endpoint or server-side filter for "retry eligible".
+- Frontend: bulk "Retry failed previews" only affects TEMPORARY items.
+
+Acceptance:
+
+- Clicking bulk retry does not re-queue PERMANENT failures.
+
+## Day 5: Observability + Diagnostics
+
+Goal:
+
+- Make preview queue and failure behavior observable.
+
+Scope:
+
+- Metrics: counters by category and mime type.
+- Logs: structured reason + category.
+- Optional: admin endpoint to sample recent failures with categories.
+
+## Day 6: Automation Coverage Expansion
+
+Goal:
+
+- Lock in the new semantics.
+
+Scope:
+
+- Playwright:
+  - mis-labeled octet-stream PDF becomes previewable
+  - permanent failure does not show queued retry count
+  - CAD disabled shows UNSUPPORTED
+- Backend:
+  - classifier tests for new error hints
+
+## Day 7: Regression Gate + Release Documentation
+
+Goal:
+
+- Run weekly subset gate and produce a short release note / delivery note.
+
+Verification:
+
+- `cd ecm-frontend && npx playwright test --workers=1 e2e/ui-smoke.spec.ts e2e/search-view.spec.ts e2e/search-preview-status.spec.ts e2e/pdf-preview.spec.ts e2e/ocr-queue-ui.spec.ts --project=chromium`
+

--- a/docs/PHASE4_D1_PREVIEW_RETRY_CLASSIFICATION_20260213.md
+++ b/docs/PHASE4_D1_PREVIEW_RETRY_CLASSIFICATION_20260213.md
@@ -1,0 +1,74 @@
+# Phase 4 Day 1 - Preview Retry Classification Hardening (2026-02-13)
+
+## Problem
+
+Preview generation failures were broadly classified as "TEMPORARY" whenever the failure reason started with:
+
+- `Error generating preview: ...`
+- `CAD preview failed: ...`
+
+This caused two practical issues:
+
+1. **Auto-retry was too aggressive**: permanent errors (for example, malformed PDFs) were treated as retryable and re-queued until attempts were exhausted.
+2. **Unsupported CAD configuration was misclassified**: when CAD preview is disabled or not configured, the system should treat it as **unsupported** (not "failed"), and the UI should not show retry actions.
+
+## Design / Approach
+
+1. **Classifier semantics**
+   - `UNSUPPORTED`: mime types that cannot be previewed (for example `application/octet-stream`) or known "unsupported" reasons.
+   - `TEMPORARY`: only when the failure reason includes transient hints (timeouts, connection resets/refusals, common 5xx codes).
+   - `PERMANENT`: default for non-unsupported, non-transient failures.
+
+2. **Queue retry policy**
+   - Preview queue retries should be driven by the classifier result:
+     - retry only when `PreviewFailureClassifier` returns `TEMPORARY`
+     - do not retry for `UNSUPPORTED` or `PERMANENT`
+
+3. **Search facet alignment**
+   - `PreviewStatusFilterHelper` keeps a phrase list used to treat legacy/FAILED entries as UNSUPPORTED for facet correctness.
+   - This list must stay aligned with `PreviewFailureClassifier.isUnsupportedReason(...)`.
+
+## Implementation Notes
+
+Backend changes:
+
+- `ecm-core/src/main/java/com/ecm/core/preview/PreviewFailureClassifier.java`
+  - Removed broad "startsWith(error generating preview)" from TEMPORARY classification.
+  - TEMPORARY is now based on transient hints only.
+  - Added CAD config failures as UNSUPPORTED reasons:
+    - `CAD preview disabled`
+    - `CAD preview service not configured`
+- `ecm-core/src/main/java/com/ecm/core/preview/PreviewQueueService.java`
+  - Queue retry decision now uses `PreviewFailureClassifier.classify(...)`.
+- `ecm-core/src/main/java/com/ecm/core/search/PreviewStatusFilterHelper.java`
+  - Added the same CAD phrases to `UNSUPPORTED_REASON_PHRASES`.
+- Tests:
+  - `ecm-core/src/test/java/com/ecm/core/preview/PreviewFailureClassifierTest.java`
+
+## Verification
+
+Backend:
+
+```bash
+cd ecm-core
+mvn -q test
+```
+
+Frontend (E2E gate subset):
+
+```bash
+cd ecm-frontend
+ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 \
+  npx playwright test \
+    e2e/ocr-queue-ui.spec.ts \
+    e2e/pdf-preview.spec.ts \
+    e2e/search-preview-status.spec.ts \
+    --project=chromium
+```
+
+Expected outcome:
+
+- Malformed/parse errors that do not include transient hints are categorized as `PERMANENT` and will not auto-retry.
+- CAD preview disabled / not configured is treated as `UNSUPPORTED`.
+- CI/local E2E expectations remain stable (no change to the preview-status filter semantics).
+

--- a/ecm-core/src/main/java/com/ecm/core/preview/PreviewFailureClassifier.java
+++ b/ecm-core/src/main/java/com/ecm/core/preview/PreviewFailureClassifier.java
@@ -61,7 +61,9 @@ public final class PreviewFailureClassifier {
         }
         return normalized.startsWith("preview not supported")
             || normalized.contains("not supported for mime type")
-            || normalized.contains("not available for empty pdf content");
+            || normalized.contains("not available for empty pdf content")
+            || normalized.contains("cad preview disabled")
+            || normalized.contains("cad preview service not configured");
     }
 
     private static boolean isTemporaryReason(String failureReason) {
@@ -69,9 +71,11 @@ public final class PreviewFailureClassifier {
         if (normalized == null) {
             return false;
         }
-        return normalized.startsWith("error generating preview")
-            || normalized.startsWith("cad preview failed")
-            || normalized.contains("timeout")
+        return containsTransientHint(normalized);
+    }
+
+    private static boolean containsTransientHint(String normalized) {
+        return normalized.contains("timeout")
             || normalized.contains("timed out")
             || normalized.contains("temporar")
             || normalized.contains("connection reset")

--- a/ecm-core/src/main/java/com/ecm/core/preview/PreviewQueueService.java
+++ b/ecm-core/src/main/java/com/ecm/core/preview/PreviewQueueService.java
@@ -21,7 +21,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Queue;
 import java.util.UUID;
@@ -298,11 +297,15 @@ public class PreviewQueueService {
             return false;
         }
         String message = result.getMessage();
-        if (message == null) {
+        if (message == null || message.isBlank()) {
             return false;
         }
-        String lower = message.toLowerCase(Locale.ROOT);
-        return lower.startsWith("error generating preview") || lower.startsWith("cad preview failed");
+        String category = PreviewFailureClassifier.classify(
+            PreviewStatus.FAILED.name(),
+            result.getMimeType(),
+            message
+        );
+        return PreviewFailureClassifier.CATEGORY_TEMPORARY.equalsIgnoreCase(category);
     }
 
     private <T> T runAsSystem(PreviewTask<T> task) throws Exception {

--- a/ecm-core/src/main/java/com/ecm/core/search/PreviewStatusFilterHelper.java
+++ b/ecm-core/src/main/java/com/ecm/core/search/PreviewStatusFilterHelper.java
@@ -53,7 +53,9 @@ final class PreviewStatusFilterHelper {
     private static final List<String> UNSUPPORTED_REASON_PHRASES = List.of(
         "preview not supported",
         "not supported for mime type",
-        "not available for empty pdf content"
+        "not available for empty pdf content",
+        "cad preview disabled",
+        "cad preview service not configured"
     );
 
     private PreviewStatusFilterHelper() {}

--- a/ecm-core/src/test/java/com/ecm/core/preview/PreviewFailureClassifierTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/preview/PreviewFailureClassifierTest.java
@@ -37,6 +37,30 @@ class PreviewFailureClassifierTest {
     }
 
     @Test
+    void treatsBadPdfParseAsPermanentFailure() {
+        assertEquals(
+            PreviewFailureClassifier.CATEGORY_PERMANENT,
+            PreviewFailureClassifier.classify("FAILED", "application/pdf", "Error generating preview: Missing root object specification in trailer.")
+        );
+    }
+
+    @Test
+    void classifiesCadPreviewDisabledAsUnsupported() {
+        assertEquals(
+            PreviewFailureClassifier.CATEGORY_UNSUPPORTED,
+            PreviewFailureClassifier.classify("FAILED", "application/acad", "CAD preview disabled")
+        );
+    }
+
+    @Test
+    void classifiesCadPreviewServiceNotConfiguredAsUnsupported() {
+        assertEquals(
+            PreviewFailureClassifier.CATEGORY_UNSUPPORTED,
+            PreviewFailureClassifier.classify("FAILED", "application/acad", "CAD preview service not configured")
+        );
+    }
+
+    @Test
     void classifiesPermanentFailureByDefault() {
         assertEquals(
             PreviewFailureClassifier.CATEGORY_PERMANENT,


### PR DESCRIPTION
## Summary

- Preview auto-retry is now limited to transient failures (timeouts/connection/5xx), avoiding wasteful retries for permanent parse errors.
- CAD preview disabled/unconfigured is treated as UNSUPPORTED (no retry actions).
- Search facet helper UNSUPPORTED phrases kept aligned with backend classifier.

## Docs

- Phase 4 plan: `docs/NEXT_7DAY_PLAN_PHASE4_20260213.md`
- Day 1 note: `docs/PHASE4_D1_PREVIEW_RETRY_CLASSIFICATION_20260213.md`

## Verification

```bash
cd ecm-core && mvn -q test

cd ecm-frontend
ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 \
  npx playwright test \
    e2e/ocr-queue-ui.spec.ts \
    e2e/pdf-preview.spec.ts \
    e2e/search-preview-status.spec.ts \
    --project=chromium
```
