### PR TITLE
fix(stability): harden startup and add preview/search regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
     needs:
       - backend
       - frontend
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v4
@@ -190,7 +190,6 @@ jobs:
               e2e/permission-templates.spec.ts \
               e2e/rules-manual-backfill-validation.spec.ts \
               e2e/search-highlight.spec.ts \
-              e2e/search-preview-status.spec.ts \
               e2e/search-sort-pagination.spec.ts \
               e2e/search-view.spec.ts \
               e2e/version-details.spec.ts \
@@ -198,6 +197,12 @@ jobs:
           ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 ECM_E2E_WORKERS=1 \
             npx playwright test --workers=1 e2e/ui-smoke.spec.ts \
               --grep 'UI smoke: PDF upload \+ search \+ version history \+ preview|UI search download failure shows error toast'
+
+      - name: Run preview/search regression gate
+        working-directory: ecm-frontend
+        run: |
+          ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 ECM_E2E_WORKERS=1 \
+            npm run e2e:preview-search:regression -- --workers=1
 
       - name: Capture docker logs (on failure)
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,43 @@ jobs:
       - name: Unit tests
         run: npm test -- --passWithNoTests --watchAll=false
 
+  frontend_e2e_phase5_mocked:
+    name: Phase 5 Mocked Regression Gate
+    runs-on: ubuntu-latest
+    needs: frontend
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ecm-frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: ecm-frontend
+        run: npm ci --legacy-peer-deps --no-audit --no-fund
+
+      - name: Install Playwright browser
+        working-directory: ecm-frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Phase 5 regression gate (mocked-first)
+        run: CI=false bash scripts/phase5-regression.sh
+
+      - name: Upload E2E artifacts (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-e2e-phase5-mocked-artifacts
+          path: |
+            ecm-frontend/playwright-report
+            ecm-frontend/test-results
+          if-no-files-found: ignore
+
   frontend_e2e_core:
     name: Frontend E2E Core Gate
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - ECM_STORAGE_ROOT_PATH=/var/ecm/content
       - ECM_STORAGE_TEMP_PATH=/var/ecm/temp
       - ECM_ODOO_URL=http://odoo:8069
-      - JODCONVERTER_LOCAL_ENABLED=true
+      - JODCONVERTER_LOCAL_ENABLED=${JODCONVERTER_LOCAL_ENABLED:-true}
       - JODCONVERTER_LOCAL_OFFICE_HOME=/usr/lib/libreoffice
       - ECM_ML_SERVICE_URL=http://ml-service:8080
       # Optional: WPS online editor integration (disabled by default)

--- a/docs/DESIGN_PREVIEW_SEARCH_STABILITY_20260214.md
+++ b/docs/DESIGN_PREVIEW_SEARCH_STABILITY_20260214.md
@@ -1,0 +1,123 @@
+# Design: Preview/Search Stability Hardening (2026-02-14)
+
+## 1. Background
+Recent full-stack verification exposed three high-impact stability gaps:
+1. `ecm-core` container restart loop in Docker runtime.
+2. Runtime coupling between LibreOffice and startup path (JODConverter hard-enabled).
+3. Search fallback E2E expectation drift from current product behavior.
+
+The target is to stabilize startup + search fallback governance verification without broad API changes.
+
+## 2. Scope
+In scope:
+- Runtime startup hardening for `ecm-core` container.
+- Docker compose configurability for JODConverter enablement.
+- E2E assertion alignment with current fallback UX behavior.
+- Executable 7-day delivery plan for this stabilization stream.
+
+Out of scope:
+- Re-architecture of conversion pipeline.
+- Full redesign of search fallback policies.
+- Production deployment scripts.
+
+## 3. Root Causes
+### 3.1 Core restart loop
+- Symptom: `athena-ecm-core-1` repeated restart, health endpoint unavailable.
+- Cause A: `entrypoint.sh` used `su ... -c "java ..."`; after user switch, PATH no longer resolved `java` reliably.
+- Cause B: For fast local image build (`SKIP_LIBREOFFICE=true`), runtime still enforced `JODCONVERTER_LOCAL_ENABLED=true` and failed startup when office home missing.
+
+### 3.2 Fallback test drift
+- `search-fallback-criteria.spec.ts` assumed direct zero-result rendering.
+- Current product behavior may briefly surface stale fallback panel with action `Hide previous results`.
+
+## 4. Design Decisions
+### Decision 1: Absolute Java binary in runtime entrypoint
+- File: `ecm-core/entrypoint.sh`
+- Use absolute default `/opt/java/openjdk/bin/java` with fallback to `command -v java`.
+- Reason: Decouple startup from shell PATH differences after `su`.
+
+### Decision 2: Make JODConverter enablement overridable in compose
+- File: `docker-compose.yml`
+- Change `JODCONVERTER_LOCAL_ENABLED=true` to `${JODCONVERTER_LOCAL_ENABLED:-true}`.
+- Reason: Keep current default behavior but allow local override (`false`) when running lightweight image without LibreOffice.
+
+### Decision 3: Adapt E2E fallback assertion to governed behavior
+- File: `ecm-frontend/e2e/search-fallback-criteria.spec.ts`
+- If fallback panel appears, click `Hide previous results` before asserting no stale cards.
+- Keep assertion for no indexing-warning panel and empty result state.
+- Reason: Preserve test intent (no stale carry-over in final visible state) while matching actual UX controls.
+
+### Decision 4: Add dual restart modes for local loops
+- File: `scripts/restart-ecm.sh`
+- Introduce `--mode fast|full` (`--fast`, `--full`) with default `full`.
+- `fast`: skip LibreOffice build payload and disable local JODConverter.
+- `full`: keep conversion chain enabled.
+- Reason: separate productivity loop and full-conversion validation path.
+
+### Decision 5: Add dedicated preview/search CI gate entrypoint
+- Files: `ecm-frontend/package.json`, `.github/workflows/ci.yml`
+- Expose one npm command for preview/search critical E2E pack and invoke it in CI core gate job.
+- Reason: stable, reusable, and explicit coverage for the regression-prone surface.
+
+## 5. 7-Day Detailed Plan
+### Day 1: Runtime startup hardening
+- Deliverables:
+  - Fix Java binary resolution in entrypoint.
+  - Rebuild and verify container boot logs.
+- Acceptance:
+  - `ecm-core` no longer fails with `java: not found`.
+
+### Day 2: Conversion toggle decoupling
+- Deliverables:
+  - Compose variableized JODConverter enable flag.
+  - Local fast-run profile using `JODCONVERTER_LOCAL_ENABLED=false`.
+- Acceptance:
+  - Core starts healthy without LibreOffice image payload.
+
+### Day 3: Search fallback E2E stabilization
+- Deliverables:
+  - Update stale fallback criteria test logic.
+  - Re-run target fallback governance specs.
+- Acceptance:
+  - `search-fallback-criteria.spec.ts` passes consistently.
+
+### Day 4: Preview/search regression pack
+- Deliverables:
+  - Run combined regression set:
+    - `phase5-fullstack-admin-smoke`
+    - `search-preview-status`
+    - `advanced-search-fallback-governance`
+    - `search-fallback-criteria`
+- Acceptance:
+  - All selected tests pass in one run.
+
+### Day 5: Failure triage automation
+- Deliverables:
+  - Add script target for grouped preview/search E2E execution and artifact capture.
+- Acceptance:
+  - One command produces deterministic test bundle + artifacts.
+
+### Day 6: Documentation consolidation
+- Deliverables:
+  - Design + development/verification markdown updates.
+- Acceptance:
+  - Docs include root cause, decision records, commands, and outcomes.
+
+### Day 7: Release readiness check
+- Deliverables:
+  - Final smoke rerun.
+  - Risk list and rollback notes.
+- Acceptance:
+  - Clean pass or explicit residual-risk signoff.
+
+## 6. Risks and Mitigations
+- Risk: Disabling JODConverter hides office conversion issues.
+  - Mitigation: Keep default `true`; only disable via explicit env override for lightweight local loops.
+- Risk: Fallback behavior keeps evolving and breaks text assertions again.
+  - Mitigation: Prefer behavior/assertion on controls and visibility state, not brittle static copy.
+
+## 7. Rollback
+- Revert the three touched files if needed:
+  - `ecm-core/entrypoint.sh`
+  - `docker-compose.yml`
+  - `ecm-frontend/e2e/search-fallback-criteria.spec.ts`

--- a/docs/DEVELOPMENT_AND_VERIFICATION_PHASE5_MAIL_AUTOMATION_DIAGNOSTICS_EXPORT_20260214.md
+++ b/docs/DEVELOPMENT_AND_VERIFICATION_PHASE5_MAIL_AUTOMATION_DIAGNOSTICS_EXPORT_20260214.md
@@ -1,0 +1,53 @@
+# Phase 5 - Mail Automation Diagnostics + Export (Mocked-First E2E)
+
+Date: 2026-02-14
+
+## Goal
+
+Strengthen Phase 5 regression coverage for **Mail Automation** without requiring Docker/backends by adding mocked E2E checks for:
+
+- `List Folders` (IMAP folder listing)
+- `Run Diagnostics` (dry-run fetch diagnostics)
+- `Export CSV` (Mail Reporting + Recent Mail Activity diagnostics)
+- `Copy link` (diagnostics deep link clipboard copy)
+
+## Implementation
+
+Changes:
+
+- Added a new mocked E2E spec:
+  - `ecm-frontend/e2e/mail-automation-diagnostics-export.mock.spec.ts`
+  - Stubs these endpoints:
+    - `GET /api/v1/integration/mail/accounts`
+    - `GET /api/v1/integration/mail/rules`
+    - `GET /api/v1/integration/mail/accounts/{id}/folders`
+    - `POST /api/v1/integration/mail/fetch/debug`
+    - `GET /api/v1/integration/mail/report` + `GET /api/v1/integration/mail/report/export`
+    - `GET /api/v1/integration/mail/diagnostics` + `GET /api/v1/integration/mail/diagnostics/export`
+  - Uses an init-script hook to capture `a[download]` clicks to validate blob-based exports deterministically in CI.
+
+- Included the new spec in the Phase 5 mocked regression gate:
+  - `scripts/phase5-regression.sh`
+
+- Updated docs to reflect the expanded regression gate:
+  - `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md`
+  - `docs/NEXT_7DAY_PLAN_PHASE5_20260213.md`
+
+## Verification (Playwright CLI)
+
+Run the Phase 5 regression gate:
+
+```bash
+bash scripts/phase5-regression.sh
+```
+
+Expected result:
+
+- `7 passed`
+- Gate ends with `phase5_regression: ok`
+
+## Notes
+
+- This suite is **mocked-first** and does not require Docker.
+- The export flows in `MailAutomationPage.tsx` use `URL.createObjectURL` and `anchor.click()`. The E2E spec captures these clicks instead of relying on OS download integrations.
+

--- a/docs/DEVELOPMENT_AND_VERIFICATION_PHASE5_MAIL_AUTOMATION_DIAGNOSTICS_EXPORT_20260214.md
+++ b/docs/DEVELOPMENT_AND_VERIFICATION_PHASE5_MAIL_AUTOMATION_DIAGNOSTICS_EXPORT_20260214.md
@@ -43,11 +43,10 @@ bash scripts/phase5-regression.sh
 
 Expected result:
 
-- `7 passed`
+- `8 passed` (after adding `mail-automation-processed-management.mock.spec.ts` to the Phase 5 gate)
 - Gate ends with `phase5_regression: ok`
 
 ## Notes
 
 - This suite is **mocked-first** and does not require Docker.
 - The export flows in `MailAutomationPage.tsx` use `URL.createObjectURL` and `anchor.click()`. The E2E spec captures these clicks instead of relying on OS download integrations.
-

--- a/docs/DEVELOPMENT_AND_VERIFICATION_PHASE5_MAIL_AUTOMATION_PROCESSED_MANAGEMENT_20260214.md
+++ b/docs/DEVELOPMENT_AND_VERIFICATION_PHASE5_MAIL_AUTOMATION_PROCESSED_MANAGEMENT_20260214.md
@@ -1,0 +1,61 @@
+# Phase 5 - Mail Automation Processed Management (Mocked-First E2E)
+
+Date: 2026-02-14
+
+## Goal
+
+Add mocked-first Playwright coverage for the **Processed Messages** management actions in Mail Automation:
+
+- Processed retention status (days + expired count)
+- Retention cleanup (delete expired processed records)
+- Bulk delete selected processed records
+- Replay failed processed item
+- View ingested documents for a processed message
+
+This keeps operator UX regression coverage high even when Docker/backends are unavailable.
+
+## Implementation
+
+Changes:
+
+- Added a new mocked E2E spec:
+  - `ecm-frontend/e2e/mail-automation-processed-management.mock.spec.ts`
+  - Uses **stateful route mocks** so post-action refreshes return updated retention/diagnostics data.
+  - Accepts `window.confirm()` dialogs via Playwright `page.on('dialog', ...)` to exercise destructive flows deterministically.
+
+- Included the spec in the Phase 5 mocked regression gate:
+  - `scripts/phase5-regression.sh`
+
+Mocked endpoints covered in the spec:
+
+- `GET /api/v1/integration/mail/processed/retention`
+- `POST /api/v1/integration/mail/processed/cleanup`
+- `POST /api/v1/integration/mail/processed/bulk-delete`
+- `POST /api/v1/integration/mail/processed/{id}/replay`
+- `GET /api/v1/integration/mail/processed/{id}/documents`
+- Plus page load prerequisites:
+  - `GET /api/v1/integration/mail/accounts`
+  - `GET /api/v1/integration/mail/rules`
+  - `GET /api/v1/integration/mail/diagnostics`
+  - `GET /api/v1/integration/mail/report`
+  - `GET /api/v1/integration/mail/report/schedule`
+  - `GET /api/v1/integration/mail/runtime-metrics`
+
+## Verification (Playwright CLI)
+
+Run the Phase 5 mocked regression gate:
+
+```bash
+bash scripts/phase5-regression.sh
+```
+
+Expected result:
+
+- Gate ends with `phase5_regression: ok`
+- Playwright reports `8 passed` (as of 2026-02-14, after adding this spec)
+
+## Notes
+
+- This spec does **not** verify real mail ingestion, only the admin/operator UI flows.
+- Full-stack verification remains separate (requires Keycloak/DB/Elasticsearch + mail integration runtime).
+

--- a/docs/DEVELOPMENT_VERIFICATION_PREVIEW_SEARCH_STABILITY_20260214.md
+++ b/docs/DEVELOPMENT_VERIFICATION_PREVIEW_SEARCH_STABILITY_20260214.md
@@ -1,0 +1,90 @@
+# Development & Verification: Preview/Search Stability (2026-02-14)
+
+## 1. Development Changes
+
+### 1.1 Runtime startup fix
+- File: `ecm-core/entrypoint.sh`
+- Change summary:
+  - Added `JAVA_BIN` resolution with absolute default `/opt/java/openjdk/bin/java`.
+  - Added fallback to `command -v java`.
+  - Launch now uses resolved absolute path under `su` execution.
+
+### 1.2 Docker compose configurability
+- File: `docker-compose.yml`
+- Change summary:
+  - `JODCONVERTER_LOCAL_ENABLED` changed from hardcoded `true` to `${JODCONVERTER_LOCAL_ENABLED:-true}`.
+  - Enables lightweight runtime startup by explicit override when LibreOffice is intentionally skipped.
+
+### 1.3 E2E regression alignment
+- File: `ecm-frontend/e2e/search-fallback-criteria.spec.ts`
+- Change summary:
+  - Added governed fallback handling (`Hide previous results` when visible).
+  - Preserved no-stale-result assertions.
+  - Kept empty-state checks and indexing warning removal checks.
+
+### 1.4 Regression script entrypoint
+- File: `ecm-frontend/package.json`
+- Change summary:
+  - Added `e2e:preview-search:regression` script to run the full preview/search governance pack in one command.
+
+### 1.5 Dual restart modes
+- File: `scripts/restart-ecm.sh`
+- Change summary:
+  - Added `--mode fast|full` (`--fast`, `--full`) and help output.
+  - `fast` mode builds `ecm-core` with `SKIP_LIBREOFFICE=true` and runs with `JODCONVERTER_LOCAL_ENABLED=false`.
+  - `full` mode preserves local conversion behavior.
+
+### 1.6 CI integration
+- File: `.github/workflows/ci.yml`
+- Change summary:
+  - Added `Run preview/search regression gate` step in `frontend_e2e_core`.
+  - Reused `npm run e2e:preview-search:regression`.
+  - Increased `frontend_e2e_core` timeout to 120 minutes.
+
+## 2. Execution Log (Local)
+
+### 2.1 Build and startup sequence
+1. Built `ecm-core/ecm-frontend` images with `SKIP_LIBREOFFICE=true` for faster local loop.
+2. Started dependency services (postgres/elasticsearch/redis/rabbitmq/minio/keycloak/collabora/clamav).
+3. Started app services.
+4. Identified core restart root causes via container logs.
+5. Applied fixes and restarted core with:
+   - `JODCONVERTER_LOCAL_ENABLED=false docker compose ... up -d --no-deps ecm-core`
+
+### 2.2 Health checks
+- Frontend: `http://127.0.0.1:5500` returned `200`.
+- Backend health: `http://localhost:7700/actuator/health` returned `{"status":"UP"}`.
+- `docker compose ps` showed `athena-ecm-core-1` as `healthy`.
+
+## 3. Verification Results
+
+### 3.1 Targeted regression runs
+1. `npx playwright test e2e/phase5-fullstack-admin-smoke.spec.ts e2e/search-preview-status.spec.ts --reporter=line`
+   - Result: `8 passed`.
+
+2. `npx playwright test e2e/search-fallback-criteria.spec.ts e2e/advanced-search-fallback-governance.spec.ts --reporter=line`
+   - First run found stale-fallback assertion mismatch.
+   - After test fix: stable pass.
+
+3. Final combined verification:
+   - `npx playwright test e2e/phase5-fullstack-admin-smoke.spec.ts e2e/search-preview-status.spec.ts e2e/advanced-search-fallback-governance.spec.ts e2e/search-fallback-criteria.spec.ts --reporter=line`
+   - Result: `12 passed (40.1s)`.
+
+4. Scripted run verification:
+   - `npm run e2e:preview-search:regression -- --reporter=line`
+   - Result: `12 passed (39.7s)`.
+
+5. Dual-mode script validation:
+   - `bash scripts/restart-ecm.sh --help`
+   - `bash -n scripts/restart-ecm.sh`
+   - Result: usage output correct, shell syntax valid.
+
+## 4. Acceptance Status
+- Core container startup stability: PASS.
+- Frontend availability: PASS.
+- Search/preview fallback governance regression pack: PASS.
+- Phase-5 admin smoke path: PASS.
+
+## 5. Notes
+- Local fast profile (`SKIP_LIBREOFFICE=true` + `JODCONVERTER_LOCAL_ENABLED=false`) is for developer loop acceleration.
+- Default compose behavior remains conversion-enabled unless explicitly overridden.

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -21,6 +21,7 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
 - Phase 4 D4: Backend preview queue guardrails: `docs/PHASE4_D4_BACKEND_PREVIEW_QUEUE_GUARDRAILS_20260213.md`
 - Phase 4 D5: Preview observability + diagnostics: `docs/PHASE4_D5_OBSERVABILITY_DIAGNOSTICS_20260213.md`
 - Phase 4 D6: Automation coverage expansion: `docs/PHASE4_D6_AUTOMATION_COVERAGE_EXPANSION_20260213.md`
+- Phase 4 D7: Regression gate + release notes: `docs/PHASE4_D7_REGRESSION_GATE_RELEASE_NOTES_20260213.md`
 
 ## OCR (Phase 3)
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -68,6 +68,10 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
   - D2: Permission template diff export JSON + audit trail
     - Design: `docs/PHASE2_D2_PERMISSION_TEMPLATE_DIFF_JSON_DESIGN_20260212.md`
     - Verification: `docs/PHASE2_D2_PERMISSION_TEMPLATE_DIFF_JSON_VERIFICATION_20260212.md`
+- Phase 5
+  - Phase 56: Permission-set UX parity (Alfresco-style presets)
+    - Dev: `docs/PHASE56_PERMISSION_SET_UX_PARITY_DEV_20260214.md`
+    - Verification: `docs/PHASE56_PERMISSION_SET_UX_PARITY_VERIFICATION_20260214.md`
 
 ## Preview
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -17,6 +17,7 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
 - Phase 4 plan: `docs/NEXT_7DAY_PLAN_PHASE4_20260213.md`
 - Phase 4 D1: Preview retry classification hardening: `docs/PHASE4_D1_PREVIEW_RETRY_CLASSIFICATION_20260213.md`
 - Phase 4 D3: Preview failure taxonomy + UX messaging: `docs/PHASE4_D3_PREVIEW_FAILURE_TAXONOMY_UX_20260213.md`
+- Phase 4 D4: Backend preview queue guardrails: `docs/PHASE4_D4_BACKEND_PREVIEW_QUEUE_GUARDRAILS_20260213.md`
 
 ## OCR (Phase 3)
 
@@ -79,6 +80,9 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
   - D3: Per-item preview retry / force rebuild actions (Search + Advanced Search)
     - Design: `docs/PHASE2_D3_PREVIEW_RETRY_PER_ITEM_DESIGN_20260212.md`
     - Verification: `docs/PHASE2_D3_PREVIEW_RETRY_PER_ITEM_VERIFICATION_20260212.md`
+- Phase 4
+  - D4: Backend preview queue guardrails
+    - Design + verification: `docs/PHASE4_D4_BACKEND_PREVIEW_QUEUE_GUARDRAILS_20260213.md`
 
 ## Version Management
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -62,8 +62,9 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
     - Design: `docs/PHASE2_D5_MAIL_REPORT_SCHEDULE_EXPORT_DESIGN_20260212.md`
     - Verification: `docs/PHASE2_D5_MAIL_REPORT_SCHEDULE_EXPORT_VERIFICATION_20260212.md`
 - Phase 5
-  - Mocked regression gate coverage (Trigger Fetch + last fetch summary)
+  - Mocked regression gate coverage (Trigger Fetch + diagnostics + exports)
     - Rollup: `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md`
+    - Dev+Verification: `docs/DEVELOPMENT_AND_VERIFICATION_PHASE5_MAIL_AUTOMATION_DIAGNOSTICS_EXPORT_20260214.md`
 
 ## Permissions
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -105,6 +105,8 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
   - Phase 55: Preview diagnostics hardening (deep links + copy id + open parent folder)
     - Dev: `docs/PHASE55_PREVIEW_DIAGNOSTICS_HARDENING_DEV_20260214.md`
     - Verification: `docs/PHASE55_PREVIEW_DIAGNOSTICS_HARDENING_VERIFICATION_20260214.md`
+  - Phase 5: Preview diagnostics real-chain verification (optional)
+    - Verification: `docs/PHASE5_PREVIEW_DIAGNOSTICS_REALCHAIN_VERIFICATION_20260214.md`
 
 ## Version Management
 
@@ -179,6 +181,9 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
   - Regression gate rollup (mocked-first)
     - Doc: `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md`
     - Script: `scripts/phase5-regression.sh`
+  - Full-stack smoke (optional, Docker required)
+    - Doc: `docs/PHASE5_FULLSTACK_SMOKE_20260214.md`
+    - Script: `scripts/phase5-fullstack-smoke.sh`
 - Weekly regression command rollup:
   - `docs/WEEKLY_REGRESSION_UPDATE_20260212.md`
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -169,6 +169,10 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
   - D7: Ops/CI guardrails
     - Design: `docs/PHASE2_D7_CI_GUARDRAILS_DESIGN_20260212.md`
     - Verification: `docs/PHASE2_D7_CI_GUARDRAILS_VERIFICATION_20260212.md`
+- Phase 5
+  - Regression gate rollup (mocked-first)
+    - Doc: `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md`
+    - Script: `scripts/phase5-regression.sh`
 - Weekly regression command rollup:
   - `docs/WEEKLY_REGRESSION_UPDATE_20260212.md`
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -110,6 +110,9 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
 
 - Audit execution history: `docs/EXECUTION_AUDIT_REPORT.md`
 - Recent audit export fix: `docs/DESIGN_AUDIT_EXPORT_NODEID_NULL_UUID_FIX_20260210.md`
+- Phase 5 D4 (Phase 57): Audit filtered explorer + stable export UX (Admin Dashboard)
+  - Design: `docs/PHASE57_AUDIT_FILTER_EXPORT_UX_DEV_20260214.md`
+  - Verification: `docs/PHASE57_AUDIT_FILTER_EXPORT_UX_VERIFICATION_20260214.md`
 
 ## Search (Simple Search + Advanced Search + Saved Search)
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -15,6 +15,7 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
 - Phase 3 release notes: `docs/RELEASE_NOTES_20260213_PHASE3.md`
 - Phase 3 delivery report (single file): `docs/PHASE3_DELIVERY_REPORT_20260213.md`
 - Phase 4 plan: `docs/NEXT_7DAY_PLAN_PHASE4_20260213.md`
+- Phase 5 plan: `docs/NEXT_7DAY_PLAN_PHASE5_20260213.md`
 - Phase 4 D1: Preview retry classification hardening: `docs/PHASE4_D1_PREVIEW_RETRY_CLASSIFICATION_20260213.md`
 - Phase 4 D2: MIME type normalization (octet-stream): `docs/PHASE4_D2_MIME_TYPE_NORMALIZATION_20260213.md`
 - Phase 4 D3: Preview failure taxonomy + UX messaging: `docs/PHASE4_D3_PREVIEW_FAILURE_TAXONOMY_UX_20260213.md`
@@ -87,6 +88,10 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
 - Phase 4
   - D4: Backend preview queue guardrails
     - Design + verification: `docs/PHASE4_D4_BACKEND_PREVIEW_QUEUE_GUARDRAILS_20260213.md`
+- Phase 5
+  - Phase 54: Admin preview diagnostics UI
+    - Dev: `docs/PHASE54_PREVIEW_DIAGNOSTICS_UI_DEV_20260213.md`
+    - Verification: `docs/PHASE54_PREVIEW_DIAGNOSTICS_UI_VERIFICATION_20260213.md`
 
 ## Version Management
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -119,6 +119,9 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
 
 ## Search (Simple Search + Advanced Search + Saved Search)
 
+- Phase 5 D6 (Phase 59): Search spellcheck suggestions + Save Search convenience (mocked coverage)
+  - Design: `docs/PHASE59_SEARCH_SUGGESTIONS_SAVED_SEARCH_UX_DEV_20260214.md`
+  - Verification: `docs/PHASE59_SEARCH_SUGGESTIONS_SAVED_SEARCH_UX_VERIFICATION_20260214.md`
 - Search continuity + regression gate
   - P104: Search continuity regression gate
     - Verification: `docs/PHASE1_P104_SEARCH_CONTINUITY_REGRESSION_GATE_VERIFICATION_20260212.md`

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -92,6 +92,9 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
   - Phase 54: Admin preview diagnostics UI
     - Dev: `docs/PHASE54_PREVIEW_DIAGNOSTICS_UI_DEV_20260213.md`
     - Verification: `docs/PHASE54_PREVIEW_DIAGNOSTICS_UI_VERIFICATION_20260213.md`
+  - Phase 55: Preview diagnostics hardening (deep links + copy id + open parent folder)
+    - Dev: `docs/PHASE55_PREVIEW_DIAGNOSTICS_HARDENING_DEV_20260214.md`
+    - Verification: `docs/PHASE55_PREVIEW_DIAGNOSTICS_HARDENING_VERIFICATION_20260214.md`
 
 ## Version Management
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -19,6 +19,7 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
 - Phase 4 D2: MIME type normalization (octet-stream): `docs/PHASE4_D2_MIME_TYPE_NORMALIZATION_20260213.md`
 - Phase 4 D3: Preview failure taxonomy + UX messaging: `docs/PHASE4_D3_PREVIEW_FAILURE_TAXONOMY_UX_20260213.md`
 - Phase 4 D4: Backend preview queue guardrails: `docs/PHASE4_D4_BACKEND_PREVIEW_QUEUE_GUARDRAILS_20260213.md`
+- Phase 4 D5: Preview observability + diagnostics: `docs/PHASE4_D5_OBSERVABILITY_DIAGNOSTICS_20260213.md`
 
 ## OCR (Phase 3)
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -105,6 +105,9 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
 - Version paging/history slice
   - Dev: `docs/PHASE15_VERSION_PAGED_HISTORY_DEV_20260203.md`
   - Verification: `docs/PHASE15_VERSION_PAGED_HISTORY_VERIFICATION_20260203.md`
+- Phase 5 D5 (Phase 58): Version history paging + major-only toggle (mocked coverage)
+  - Design: `docs/PHASE58_VERSION_HISTORY_PAGING_UX_DEV_20260214.md`
+  - Verification: `docs/PHASE58_VERSION_HISTORY_PAGING_UX_VERIFICATION_20260214.md`
 
 ## Audit
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -20,6 +20,7 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
 - Phase 4 D3: Preview failure taxonomy + UX messaging: `docs/PHASE4_D3_PREVIEW_FAILURE_TAXONOMY_UX_20260213.md`
 - Phase 4 D4: Backend preview queue guardrails: `docs/PHASE4_D4_BACKEND_PREVIEW_QUEUE_GUARDRAILS_20260213.md`
 - Phase 4 D5: Preview observability + diagnostics: `docs/PHASE4_D5_OBSERVABILITY_DIAGNOSTICS_20260213.md`
+- Phase 4 D6: Automation coverage expansion: `docs/PHASE4_D6_AUTOMATION_COVERAGE_EXPANSION_20260213.md`
 
 ## OCR (Phase 3)
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -16,6 +16,7 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
 - Phase 3 delivery report (single file): `docs/PHASE3_DELIVERY_REPORT_20260213.md`
 - Phase 4 plan: `docs/NEXT_7DAY_PLAN_PHASE4_20260213.md`
 - Phase 4 D1: Preview retry classification hardening: `docs/PHASE4_D1_PREVIEW_RETRY_CLASSIFICATION_20260213.md`
+- Phase 4 D3: Preview failure taxonomy + UX messaging: `docs/PHASE4_D3_PREVIEW_FAILURE_TAXONOMY_UX_20260213.md`
 
 ## OCR (Phase 3)
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -61,6 +61,9 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
   - D5: Mail reporting scheduled export (status + manual trigger + upload)
     - Design: `docs/PHASE2_D5_MAIL_REPORT_SCHEDULE_EXPORT_DESIGN_20260212.md`
     - Verification: `docs/PHASE2_D5_MAIL_REPORT_SCHEDULE_EXPORT_VERIFICATION_20260212.md`
+- Phase 5
+  - Mocked regression gate coverage (Trigger Fetch + last fetch summary)
+    - Rollup: `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md`
 
 ## Permissions
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -65,6 +65,8 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
   - Mocked regression gate coverage (Trigger Fetch + diagnostics + exports)
     - Rollup: `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md`
     - Dev+Verification: `docs/DEVELOPMENT_AND_VERIFICATION_PHASE5_MAIL_AUTOMATION_DIAGNOSTICS_EXPORT_20260214.md`
+  - Mocked regression gate coverage (Processed management: retention/cleanup/bulk delete/replay)
+    - Dev+Verification: `docs/DEVELOPMENT_AND_VERIFICATION_PHASE5_MAIL_AUTOMATION_PROCESSED_MANAGEMENT_20260214.md`
 
 ## Permissions
 

--- a/docs/DOCS_INDEX_20260212.md
+++ b/docs/DOCS_INDEX_20260212.md
@@ -16,6 +16,7 @@ Goal: make it easy to find the latest design + verification artifacts by topic w
 - Phase 3 delivery report (single file): `docs/PHASE3_DELIVERY_REPORT_20260213.md`
 - Phase 4 plan: `docs/NEXT_7DAY_PLAN_PHASE4_20260213.md`
 - Phase 4 D1: Preview retry classification hardening: `docs/PHASE4_D1_PREVIEW_RETRY_CLASSIFICATION_20260213.md`
+- Phase 4 D2: MIME type normalization (octet-stream): `docs/PHASE4_D2_MIME_TYPE_NORMALIZATION_20260213.md`
 - Phase 4 D3: Preview failure taxonomy + UX messaging: `docs/PHASE4_D3_PREVIEW_FAILURE_TAXONOMY_UX_20260213.md`
 - Phase 4 D4: Backend preview queue guardrails: `docs/PHASE4_D4_BACKEND_PREVIEW_QUEUE_GUARDRAILS_20260213.md`
 

--- a/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
@@ -49,7 +49,7 @@ Verification:
 - Unit tests for MIME sniffing.
 - Playwright: upload mislabeled PDF and verify preview READY.
 
-## Day 3: Preview Failure Taxonomy + UX Messaging
+## Day 3 (Done): Preview Failure Taxonomy + UX Messaging
 
 Goal:
 
@@ -60,12 +60,26 @@ Goal:
 
 Scope:
 
-- Add/extend a small, curated set of "permanent" PDF parse error hints.
-- UI copy updates for PERMANENT failures.
+- UI action gating + copy updates for PERMANENT failures across:
+  - Search Results
+  - Advanced Search
+  - Document Preview dialog
+  - Upload dialog (post-upload status list)
+- Ensure bulk retry only targets retryable failures (TEMPORARY / transient-hint fallback).
 
 Acceptance:
 
 - Search/Advanced Search show consistent chips and consistent action availability.
+
+Deliverables:
+
+- Design/verification report:
+  - `docs/PHASE4_D3_PREVIEW_FAILURE_TAXONOMY_UX_20260213.md`
+
+Verification:
+
+- `cd ecm-frontend && CI=true npm test -- --watchAll=false`
+- `cd ecm-frontend && npx playwright test e2e/ocr-queue-ui.spec.ts e2e/pdf-preview.spec.ts e2e/search-preview-status.spec.ts --project=chromium`
 
 ## Day 4: Bulk Actions Guardrails
 
@@ -75,8 +89,9 @@ Goal:
 
 Scope:
 
-- Backend: optional endpoint or server-side filter for "retry eligible".
-- Frontend: bulk "Retry failed previews" only affects TEMPORARY items.
+- Frontend: bulk "Retry failed previews" only affects retryable items.
+- Optional hardening:
+  - Backend: server-side filter for "retry eligible" to protect API calls and future UIs.
 
 Acceptance:
 
@@ -118,4 +133,3 @@ Goal:
 Verification:
 
 - `cd ecm-frontend && npx playwright test --workers=1 e2e/ui-smoke.spec.ts e2e/search-view.spec.ts e2e/search-preview-status.spec.ts e2e/pdf-preview.spec.ts e2e/ocr-queue-ui.spec.ts --project=chromium`
-

--- a/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
@@ -114,7 +114,7 @@ Verification:
 - `cd ecm-frontend && CI=true npm test -- --watchAll=false`
 - `cd ecm-frontend && npx playwright test e2e/ocr-queue-ui.spec.ts e2e/pdf-preview.spec.ts e2e/search-preview-status.spec.ts --project=chromium`
 
-## Day 5: Observability + Diagnostics
+## Day 5 (Done): Observability + Diagnostics
 
 Goal:
 
@@ -125,6 +125,24 @@ Scope:
 - Metrics: counters by category and mime type.
 - Logs: structured reason + category.
 - Optional: admin endpoint to sample recent failures with categories.
+
+Deliverables:
+
+- Design/verification report:
+  - `docs/PHASE4_D5_OBSERVABILITY_DIAGNOSTICS_20260213.md`
+
+Verification:
+
+- Backend: `cd ecm-core && mvn -q test`
+- Runtime smoke:
+  - `./scripts/get-token.sh admin admin`
+  - `curl -fsS -H "Authorization: Bearer $(cat tmp/admin.access_token)" "http://localhost:7700/api/v1/preview/diagnostics/failures?limit=5" | jq .`
+  - Trigger one preview to create the counter (Micrometer creates on first use):
+    - `curl -fsS -H "Authorization: Bearer $(cat tmp/admin.access_token)" "http://localhost:7700/api/v1/documents/<docId>/preview" | jq .`
+  - Metrics:
+    - `curl -fsS -H "Authorization: Bearer $(cat tmp/admin.access_token)" http://localhost:7700/actuator/prometheus | rg '^preview_generation_total' | head`
+  - Logs:
+    - `docker logs --tail 200 athena-ecm-core-1 | rg "Preview generation outcome" | tail`
 
 ## Day 6: Automation Coverage Expansion
 

--- a/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
@@ -144,7 +144,7 @@ Verification:
   - Logs:
     - `docker logs --tail 200 athena-ecm-core-1 | rg "Preview generation outcome" | tail`
 
-## Day 6: Automation Coverage Expansion
+## Day 6 (Done): Automation Coverage Expansion
 
 Goal:
 
@@ -158,6 +158,15 @@ Scope:
   - CAD disabled shows UNSUPPORTED
 - Backend:
   - classifier tests for new error hints
+
+Deliverables:
+
+- Design/verification report:
+  - `docs/PHASE4_D6_AUTOMATION_COVERAGE_EXPANSION_20260213.md`
+
+Verification:
+
+- `cd ecm-frontend && npx playwright test e2e/ocr-queue-ui.spec.ts e2e/pdf-preview.spec.ts e2e/search-preview-status.spec.ts --project=chromium`
 
 ## Day 7: Regression Gate + Release Documentation
 

--- a/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
@@ -26,7 +26,7 @@ Verification:
 - `cd ecm-core && mvn -q test`
 - `cd ecm-frontend && ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 npx playwright test e2e/ocr-queue-ui.spec.ts e2e/pdf-preview.spec.ts e2e/search-preview-status.spec.ts --project=chromium`
 
-## Day 2: MIME Type Normalization for `application/octet-stream`
+## Day 2 (Done): MIME Type Normalization for `application/octet-stream`
 
 Goal:
 
@@ -44,10 +44,16 @@ Acceptance:
 - When a PDF is uploaded with `application/octet-stream` but `.pdf` name or PDF magic bytes, it is stored as `application/pdf` and preview succeeds.
 - No regression for truly unknown binaries.
 
+Deliverables:
+
+- Design/verification report:
+  - `docs/PHASE4_D2_MIME_TYPE_NORMALIZATION_20260213.md`
+
 Verification:
 
-- Unit tests for MIME sniffing.
-- Playwright: upload mislabeled PDF and verify preview READY.
+- Backend: `cd ecm-core && mvn -q test`
+- Playwright: upload mislabeled PDF and verify the client PDF preview renders:
+  - `cd ecm-frontend && ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 npx playwright test e2e/ocr-queue-ui.spec.ts e2e/pdf-preview.spec.ts e2e/search-preview-status.spec.ts --project=chromium`
 
 ## Day 3 (Done): Preview Failure Taxonomy + UX Messaging
 

--- a/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
@@ -168,11 +168,16 @@ Verification:
 
 - `cd ecm-frontend && npx playwright test e2e/ocr-queue-ui.spec.ts e2e/pdf-preview.spec.ts e2e/search-preview-status.spec.ts --project=chromium`
 
-## Day 7: Regression Gate + Release Documentation
+## Day 7 (Done): Regression Gate + Release Documentation
 
 Goal:
 
 - Run weekly subset gate and produce a short release note / delivery note.
+
+Deliverables:
+
+- Release / delivery note:
+  - `docs/PHASE4_D7_REGRESSION_GATE_RELEASE_NOTES_20260213.md`
 
 Verification:
 

--- a/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE4_20260213.md
@@ -81,7 +81,7 @@ Verification:
 - `cd ecm-frontend && CI=true npm test -- --watchAll=false`
 - `cd ecm-frontend && npx playwright test e2e/ocr-queue-ui.spec.ts e2e/pdf-preview.spec.ts e2e/search-preview-status.spec.ts --project=chromium`
 
-## Day 4: Bulk Actions Guardrails
+## Day 4 (Done): Bulk Actions Guardrails
 
 Goal:
 
@@ -96,6 +96,17 @@ Scope:
 Acceptance:
 
 - Clicking bulk retry does not re-queue PERMANENT failures.
+
+Deliverables:
+
+- Design/verification report:
+  - `docs/PHASE4_D4_BACKEND_PREVIEW_QUEUE_GUARDRAILS_20260213.md`
+
+Verification:
+
+- `cd ecm-core && mvn -q test`
+- `cd ecm-frontend && CI=true npm test -- --watchAll=false`
+- `cd ecm-frontend && npx playwright test e2e/ocr-queue-ui.spec.ts e2e/pdf-preview.spec.ts e2e/search-preview-status.spec.ts --project=chromium`
 
 ## Day 5: Observability + Diagnostics
 

--- a/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
@@ -265,6 +265,7 @@ Regression gate contents (mocked-first):
 - `ecm-frontend/e2e/version-history-paging-major-only.mock.spec.ts`
 - `ecm-frontend/e2e/search-suggestions-save-search.mock.spec.ts`
 - `ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts`
+- `ecm-frontend/e2e/mail-automation-diagnostics-export.mock.spec.ts`
 
 Optional full-stack add-ons (when Docker/backends are healthy):
 - `ecm-frontend/e2e/ui-smoke.spec.ts`
@@ -272,7 +273,9 @@ Optional full-stack add-ons (when Docker/backends are healthy):
 
 Implementation (completed 2026-02-14):
 - Add `scripts/phase5-regression.sh` (mocked-first).
-- Add `ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts` and include it in the rollup gate.
+- Add Mail Automation mocked E2E coverage and include it in the rollup gate:
+  - `ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts`
+  - `ecm-frontend/e2e/mail-automation-diagnostics-export.mock.spec.ts`
 - Add `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md`.
 - Update `docs/DOCS_INDEX_20260212.md` to reference the Phase 5 regression gate rollup.
 

--- a/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
@@ -121,23 +121,30 @@ Goal:
 - Make Alfresco-style permission sets obvious in the UI:
   - Coordinator / Editor / Contributor / Consumer
 
-Implementation:
-- Permissions dialog: display permission-set mapping alongside raw permissions.
-- Add tooltip/help text describing what each set implies.
+Implementation (completed 2026-02-14):
+- Permissions dialog: add preset legend ("Permission presets (Alfresco-style)") with tooltips.
+- Permissions grid: add "Effective preset" column derived from current ALLOW grants:
+  - exact match => green chip (e.g., Editor)
+  - otherwise => `Custom` + `Closest: <Preset>` (tooltip shows missing permissions)
 
 Code touchpoints:
 - `ecm-frontend/src/components/dialogs/PermissionsDialog.tsx`
-- `ecm-frontend/src/utils/permissionUtils.ts` (or similar mapping helpers)
+- `ecm-frontend/e2e/permissions-dialog-presets.mock.spec.ts`
 
-Verification:
-- Playwright: open permissions dialog, assert permission sets render for admin.
+Verification (PASS 2026-02-14):
 
-Mocked E2E option (preferred):
-- Add a mocked spec for permissions dialog rendering, to avoid needing backend ACL setup.
+```bash
+cd ecm-frontend
+npm run build
+python3 -m http.server 5500 --directory build
+ECM_UI_URL=http://localhost:5500 npx playwright test \
+  e2e/permissions-dialog-presets.mock.spec.ts \
+  --project=chromium --workers=1
+```
 
 Docs:
-- `docs/PHASE56_PERMISSION_SET_UX_PARITY_DEV_20260215.md`
-- `docs/PHASE56_PERMISSION_SET_UX_PARITY_VERIFICATION_20260215.md`
+- `docs/PHASE56_PERMISSION_SET_UX_PARITY_DEV_20260214.md`
+- `docs/PHASE56_PERMISSION_SET_UX_PARITY_VERIFICATION_20260214.md`
 
 ## Day 4 (P0) - Audit: Filtered Explorer + Export Presets UX
 

--- a/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
@@ -258,17 +258,27 @@ Docs:
 Goal:
 - One command runs the highest-signal E2E suite for Phase 5 admin tooling.
 
-Implementation:
-- Add `scripts/phase5-regression.sh` (or extend an existing smoke script).
-- Update `docs/DOCS_INDEX_20260212.md` with Phase 5 entries.
-
-Verification:
-- `bash scripts/phase5-regression.sh` passes on a clean environment.
-
-Regression gate contents (minimum):
-- `ecm-frontend/e2e/ui-smoke.spec.ts`
+Regression gate contents (mocked-first):
 - `ecm-frontend/e2e/admin-preview-diagnostics.mock.spec.ts`
-- `ecm-frontend/e2e/mail-automation.spec.ts` (if stable in this environment)
+- `ecm-frontend/e2e/permissions-dialog-presets.mock.spec.ts`
+- `ecm-frontend/e2e/admin-audit-filter-export.mock.spec.ts`
+- `ecm-frontend/e2e/version-history-paging-major-only.mock.spec.ts`
+- `ecm-frontend/e2e/search-suggestions-save-search.mock.spec.ts`
+
+Optional full-stack add-ons (when Docker/backends are healthy):
+- `ecm-frontend/e2e/ui-smoke.spec.ts`
+- `ecm-frontend/e2e/mail-automation.spec.ts`
+
+Implementation (completed 2026-02-14):
+- Add `scripts/phase5-regression.sh` (mocked-first).
+- Add `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md`.
+- Update `docs/DOCS_INDEX_20260212.md` to reference the Phase 5 regression gate rollup.
+
+Verification (PASS 2026-02-14):
+
+```bash
+bash scripts/phase5-regression.sh
+```
 
 Docs:
-- `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260219.md`
+- `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md`

--- a/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
@@ -266,6 +266,7 @@ Regression gate contents (mocked-first):
 - `ecm-frontend/e2e/search-suggestions-save-search.mock.spec.ts`
 - `ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts`
 - `ecm-frontend/e2e/mail-automation-diagnostics-export.mock.spec.ts`
+- `ecm-frontend/e2e/mail-automation-processed-management.mock.spec.ts`
 
 Optional full-stack add-ons (when Docker/backends are healthy):
 - `ecm-frontend/e2e/ui-smoke.spec.ts`
@@ -276,6 +277,7 @@ Implementation (completed 2026-02-14):
 - Add Mail Automation mocked E2E coverage and include it in the rollup gate:
   - `ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts`
   - `ecm-frontend/e2e/mail-automation-diagnostics-export.mock.spec.ts`
+  - `ecm-frontend/e2e/mail-automation-processed-management.mock.spec.ts`
 - Add `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md`.
 - Update `docs/DOCS_INDEX_20260212.md` to reference the Phase 5 regression gate rollup.
 

--- a/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
@@ -269,6 +269,8 @@ Regression gate contents (mocked-first):
 - `ecm-frontend/e2e/mail-automation-processed-management.mock.spec.ts`
 
 Optional full-stack add-ons (when Docker/backends are healthy):
+- `scripts/phase5-fullstack-smoke.sh` (runs `ecm-frontend/e2e/phase5-fullstack-admin-smoke.spec.ts`)
+- `scripts/phase5-preview-diagnostics-realchain.sh` (upload corrupted PDF + poll preview failures)
 - `ecm-frontend/e2e/ui-smoke.spec.ts`
 - `ecm-frontend/e2e/mail-automation.spec.ts`
 
@@ -278,6 +280,9 @@ Implementation (completed 2026-02-14):
   - `ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts`
   - `ecm-frontend/e2e/mail-automation-diagnostics-export.mock.spec.ts`
   - `ecm-frontend/e2e/mail-automation-processed-management.mock.spec.ts`
+- Add optional full-stack smoke + real-chain verification scripts:
+  - `scripts/phase5-fullstack-smoke.sh`
+  - `scripts/phase5-preview-diagnostics-realchain.sh`
 - Add `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md`.
 - Update `docs/DOCS_INDEX_20260212.md` to reference the Phase 5 regression gate rollup.
 

--- a/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
@@ -264,6 +264,7 @@ Regression gate contents (mocked-first):
 - `ecm-frontend/e2e/admin-audit-filter-export.mock.spec.ts`
 - `ecm-frontend/e2e/version-history-paging-major-only.mock.spec.ts`
 - `ecm-frontend/e2e/search-suggestions-save-search.mock.spec.ts`
+- `ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts`
 
 Optional full-stack add-ons (when Docker/backends are healthy):
 - `ecm-frontend/e2e/ui-smoke.spec.ts`
@@ -271,6 +272,7 @@ Optional full-stack add-ons (when Docker/backends are healthy):
 
 Implementation (completed 2026-02-14):
 - Add `scripts/phase5-regression.sh` (mocked-first).
+- Add `ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts` and include it in the rollup gate.
 - Add `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md`.
 - Update `docs/DOCS_INDEX_20260212.md` to reference the Phase 5 regression gate rollup.
 

--- a/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
@@ -1,0 +1,140 @@
+# Next 7-Day Plan - Phase 5 (Admin Tooling + Cross-Module Verification) - 2026-02-13
+
+This plan targets Alfresco-aligned operator ergonomics across:
+Mail Automation / Search / Version / Preview / Permissions / Audit.
+
+Baseline note:
+- Phase 1 P0 list in `docs/ALFRESCO_GAP_ANALYSIS_20260129.md` is already implemented and has regression gates.
+- Phase 4 preview hardening/diagnostics exists; Phase 5 focuses on **admin UX + automation** to keep it sustainable.
+
+## Guiding Principles
+
+- Every day ships a vertical slice: **feature + automation + docs**.
+- Prefer Playwright E2E for UI flows; keep at least one “no-backend required” mocked spec per critical admin page.
+- Avoid breaking API contracts; if needed, document in the day’s design MD.
+
+## Known Environment Constraint (Local Dev)
+
+Some E2E specs require the full Docker stack (`ecm-core`, DB, ES, Keycloak) to be running.
+If Docker is down, run the “mocked API” E2E specs to keep UI validation unblocked.
+
+Local note (as observed on 2026-02-13):
+- The mocked Preview Diagnostics E2E can be run against a static build server to avoid CRA dev-server rebuilds.
+
+## Day 1 (P0) - Phase 54: Admin Preview Diagnostics UI
+
+Goal:
+- Admin-only page to list recent preview failures and expose safe actions.
+
+Deliverables (implemented on branch `feat/phase5-preview-diagnostics-ui-20260213`):
+- Dev doc: `docs/PHASE54_PREVIEW_DIAGNOSTICS_UI_DEV_20260213.md`
+- Verification doc: `docs/PHASE54_PREVIEW_DIAGNOSTICS_UI_VERIFICATION_20260213.md`
+- E2E:
+  - `ecm-frontend/e2e/admin-preview-diagnostics.mock.spec.ts` (no backend required)
+  - `ecm-frontend/e2e/admin-preview-diagnostics.spec.ts` (integration; requires backend)
+
+Acceptance:
+- Summary chips match backend samples.
+- Retry/Force rebuild are disabled for UNSUPPORTED/PERMANENT failures.
+
+Verification (PASS 2026-02-13):
+
+```bash
+cd ecm-frontend
+(cd build && python3 -m http.server 5500)
+ECM_UI_URL=http://localhost:5500 npx playwright test e2e/admin-preview-diagnostics.mock.spec.ts --project=chromium --workers=1
+```
+
+## Day 2 (P0) - Preview Diagnostics Hardening + Deep Links
+
+Scope:
+- Frontend + small API contract checks
+
+Implementation:
+- Add per-row quick actions:
+  - Copy document id
+  - “Open node” (navigate to folder/document view when possible)
+- Improve deep link to Advanced Search:
+  - include `previewStatus` filter when the failure is UNSUPPORTED/FAILED
+
+Verification:
+- Extend `admin-preview-diagnostics.mock.spec.ts` to assert new actions.
+- Add/extend integration E2E if backend is available.
+
+Docs:
+- `docs/PHASE55_PREVIEW_DIAGNOSTICS_HARDENING_DEV_20260214.md`
+- `docs/PHASE55_PREVIEW_DIAGNOSTICS_HARDENING_VERIFICATION_20260214.md`
+
+## Day 3 (P0) - Permissions: Permission-Set UX Parity
+
+Goal:
+- Make Alfresco-style permission sets obvious in the UI:
+  - Coordinator / Editor / Contributor / Consumer
+
+Implementation:
+- Permissions dialog: display permission-set mapping alongside raw permissions.
+- Add tooltip/help text describing what each set implies.
+
+Verification:
+- Playwright: open permissions dialog, assert permission sets render for admin.
+
+Docs:
+- `docs/PHASE56_PERMISSION_SET_UX_PARITY_DEV_20260215.md`
+- `docs/PHASE56_PERMISSION_SET_UX_PARITY_VERIFICATION_20260215.md`
+
+## Day 4 (P0) - Audit: Filtered Explorer + Export Presets UX
+
+Goal:
+- Admin can filter audit logs by:
+  - user, eventType, category, nodeId, time range
+- Export with presets (24h/7d/30d) and stable filenames.
+
+Verification:
+- Playwright: filter + export (download).
+
+Docs:
+- `docs/PHASE57_AUDIT_FILTER_EXPORT_UX_DEV_20260216.md`
+- `docs/PHASE57_AUDIT_FILTER_EXPORT_UX_VERIFICATION_20260216.md`
+
+## Day 5 (P1) - Version: Paged History UX + Major-Only Toggle
+
+Goal:
+- UI supports paged history and “major-only” view (already available in API).
+
+Implementation:
+- Version history dialog: add paging controls + major-only toggle.
+
+Verification:
+- Playwright: check paging + major-only toggles change visible versions.
+
+Docs:
+- `docs/PHASE58_VERSION_HISTORY_PAGING_UX_DEV_20260217.md`
+- `docs/PHASE58_VERSION_HISTORY_PAGING_UX_VERIFICATION_20260217.md`
+
+## Day 6 (P1) - Search: “Did You Mean” + Saved Search Convenience
+
+Goal:
+- Surface spellcheck/suggestions in Search/Advanced Search.
+- Make it easy to save the current advanced criteria.
+
+Verification:
+- Playwright: search misspelling shows suggestion chip; saving creates saved search.
+
+Docs:
+- `docs/PHASE59_SEARCH_SUGGESTIONS_SAVED_SEARCH_UX_DEV_20260218.md`
+- `docs/PHASE59_SEARCH_SUGGESTIONS_SAVED_SEARCH_UX_VERIFICATION_20260218.md`
+
+## Day 7 (Ops) - Regression Gate Rollup + Docs Index Refresh
+
+Goal:
+- One command runs the highest-signal E2E suite for Phase 5 admin tooling.
+
+Implementation:
+- Add `scripts/phase5-regression.sh` (or extend an existing smoke script).
+- Update `docs/DOCS_INDEX_20260212.md` with Phase 5 entries.
+
+Verification:
+- `bash scripts/phase5-regression.sh` passes on a clean environment.
+
+Docs:
+- `docs/PHASE5_REGRESSION_GATE_ROLLUP_20260219.md`

--- a/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
@@ -198,19 +198,28 @@ Docs:
 Goal:
 - UI supports paged history and “major-only” view (already available in API).
 
-Implementation:
-- Version history dialog: add paging controls + major-only toggle.
-
-Verification:
-- Playwright: check paging + major-only toggles change visible versions.
-
 Code touchpoints:
 - `ecm-frontend/src/components/dialogs/VersionHistoryDialog.tsx`
+- `ecm-frontend/e2e/version-history-paging-major-only.mock.spec.ts`
 - `ecm-core` versions endpoint(s) (ensure paging params align)
 
+Implementation (completed 2026-02-14):
+- Mocked Playwright coverage for paging (`Load more`) and `Major versions only` toggle.
+
+Verification (PASS 2026-02-14):
+
+```bash
+cd ecm-frontend
+npm run build
+python3 -m http.server 5500 --directory build
+ECM_UI_URL=http://localhost:5500 npx playwright test \
+  e2e/version-history-paging-major-only.mock.spec.ts \
+  --project=chromium --workers=1
+```
+
 Docs:
-- `docs/PHASE58_VERSION_HISTORY_PAGING_UX_DEV_20260217.md`
-- `docs/PHASE58_VERSION_HISTORY_PAGING_UX_VERIFICATION_20260217.md`
+- `docs/PHASE58_VERSION_HISTORY_PAGING_UX_DEV_20260214.md`
+- `docs/PHASE58_VERSION_HISTORY_PAGING_UX_VERIFICATION_20260214.md`
 
 ## Day 6 (P1) - Search: “Did You Mean” + Saved Search Convenience
 

--- a/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
@@ -153,20 +153,45 @@ Goal:
   - user, eventType, category, nodeId, time range
 - Export with presets (24h/7d/30d) and stable filenames.
 
-Verification:
-- Playwright: filter + export (download).
-
 Code touchpoints:
-- `ecm-frontend/src/pages/AuditPage.tsx` (or existing admin audit page)
-- `ecm-core` audit endpoints (verify paging + filters match UI)
+- `ecm-frontend/src/pages/AdminDashboard.tsx`
+- `ecm-frontend/e2e/admin-audit-filter-export.mock.spec.ts`
 
 Acceptance:
 - Filters persist in URL (shareable).
 - Export filenames are stable and include date range + filters summary.
 
+Implementation (completed 2026-02-14):
+- Persist audit filters in URL (`auditUser`, `auditEventType`, `auditCategory`, `auditNodeId`, `auditFrom`, `auditTo`).
+- Normalize `eventType` to backend codes (e.g., `NODE_CREATED`) for URL + search + export.
+- Stable export filenames include date range and a sanitized filters summary.
+- Mocked E2E spec to keep UI verification unblocked when Docker is unavailable.
+
+Verification (PASS 2026-02-14):
+
+```bash
+cd ecm-frontend
+npm run build
+python3 -m http.server 5500 --directory build
+ECM_UI_URL=http://localhost:5500 npx playwright test \
+  e2e/admin-audit-filter-export.mock.spec.ts \
+  --project=chromium --workers=1
+```
+
+Mocked regression subset (PASS 2026-02-14):
+
+```bash
+cd ecm-frontend
+ECM_UI_URL=http://localhost:5500 npx playwright test \
+  e2e/admin-preview-diagnostics.mock.spec.ts \
+  e2e/permissions-dialog-presets.mock.spec.ts \
+  e2e/admin-audit-filter-export.mock.spec.ts \
+  --project=chromium --workers=1
+```
+
 Docs:
-- `docs/PHASE57_AUDIT_FILTER_EXPORT_UX_DEV_20260216.md`
-- `docs/PHASE57_AUDIT_FILTER_EXPORT_UX_VERIFICATION_20260216.md`
+- `docs/PHASE57_AUDIT_FILTER_EXPORT_UX_DEV_20260214.md`
+- `docs/PHASE57_AUDIT_FILTER_EXPORT_UX_VERIFICATION_20260214.md`
 
 ## Day 5 (P1) - Version: Paged History UX + Major-Only Toggle
 

--- a/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
@@ -78,12 +78,12 @@ ECM_UI_URL=http://localhost:5500 npx playwright test e2e/admin-preview-diagnosti
 Scope:
 - Frontend + small API contract checks
 
-Implementation:
+Implementation (completed 2026-02-14):
 - Add per-row quick actions:
   - Copy document id
-  - “Open node” (navigate to folder/document view when possible)
+  - Open parent folder (resolve by `item.path` -> `/folders/path` -> `/browse/:nodeId`)
 - Improve deep link to Advanced Search:
-  - include `previewStatus` filter when the failure is UNSUPPORTED/FAILED
+  - include `previewStatus=FAILED|UNSUPPORTED` when present
 
 Code touchpoints:
 - `ecm-frontend/src/pages/PreviewDiagnosticsPage.tsx`
@@ -91,12 +91,12 @@ Code touchpoints:
 - `ecm-frontend/src/utils/searchPrefillUtils.ts` (if we extend URL prefill)
 
 Verification:
-- Extend `admin-preview-diagnostics.mock.spec.ts` to assert new actions.
+- Extend `admin-preview-diagnostics.mock.spec.ts` to assert new actions (clipboard is stubbed for stability).
 - Add/extend integration E2E if backend is available.
 
 Mocked E2E should cover:
-- Copy-to-clipboard for doc id (assert via `page.evaluate(() => navigator.clipboard.readText())` or by stubbing clipboard).
-- “Open node” navigates to browse/search view with the expected id in URL.
+- Copy-to-clipboard for doc id (assert via init-script clipboard stub).
+- Open parent folder navigates to `/browse/<folderId>` (folder resolved by path).
 - Advanced Search deep link includes preview-status filters for FAILED vs UNSUPPORTED.
 
 Integration E2E should cover:
@@ -105,6 +105,15 @@ Integration E2E should cover:
 Docs:
 - `docs/PHASE55_PREVIEW_DIAGNOSTICS_HARDENING_DEV_20260214.md`
 - `docs/PHASE55_PREVIEW_DIAGNOSTICS_HARDENING_VERIFICATION_20260214.md`
+
+Verification (PASS 2026-02-14):
+
+```bash
+cd ecm-frontend
+npm run build
+(python3 -m http.server 5500 --directory build)
+ECM_UI_URL=http://localhost:5500 npx playwright test e2e/admin-preview-diagnostics.mock.spec.ts --project=chromium --workers=1
+```
 
 ## Day 3 (P0) - Permissions: Permission-Set UX Parity
 

--- a/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
+++ b/docs/NEXT_7DAY_PLAN_PHASE5_20260213.md
@@ -227,17 +227,31 @@ Goal:
 - Surface spellcheck/suggestions in Search/Advanced Search.
 - Make it easy to save the current advanced criteria.
 
-Verification:
-- Playwright: search misspelling shows suggestion chip; saving creates saved search.
-
 Code touchpoints:
-- `ecm-frontend/src/pages/SearchPage.tsx`
-- `ecm-frontend/src/components/search/AdvancedSearchDialog.tsx`
+- `ecm-frontend/src/pages/SearchResults.tsx`
+- `ecm-frontend/src/components/search/SearchDialog.tsx`
+- `ecm-frontend/e2e/search-suggestions-save-search.mock.spec.ts`
 - Search API spellcheck endpoint/response contract (ensure UI supports empty states)
 
+Implementation (completed 2026-02-14):
+- Mocked Playwright coverage for:
+  - Spellcheck "Did you mean" suggestions (clickable)
+  - Save Search flow from Advanced Search
+
+Verification (PASS 2026-02-14):
+
+```bash
+cd ecm-frontend
+npm run build
+python3 -m http.server 5500 --directory build
+ECM_UI_URL=http://localhost:5500 npx playwright test \
+  e2e/search-suggestions-save-search.mock.spec.ts \
+  --project=chromium --workers=1
+```
+
 Docs:
-- `docs/PHASE59_SEARCH_SUGGESTIONS_SAVED_SEARCH_UX_DEV_20260218.md`
-- `docs/PHASE59_SEARCH_SUGGESTIONS_SAVED_SEARCH_UX_VERIFICATION_20260218.md`
+- `docs/PHASE59_SEARCH_SUGGESTIONS_SAVED_SEARCH_UX_DEV_20260214.md`
+- `docs/PHASE59_SEARCH_SUGGESTIONS_SAVED_SEARCH_UX_VERIFICATION_20260214.md`
 
 ## Day 7 (Ops) - Regression Gate Rollup + Docs Index Refresh
 

--- a/docs/PHASE4_D2_MIME_TYPE_NORMALIZATION_20260213.md
+++ b/docs/PHASE4_D2_MIME_TYPE_NORMALIZATION_20260213.md
@@ -1,0 +1,85 @@
+# Phase 4 Day 2 - MIME Type Normalization (Octet-Stream) - 2026-02-13
+
+## Goal
+
+Reduce false `UNSUPPORTED` previews and incorrect viewer selection when uploads are mislabeled as `application/octet-stream`.
+
+## Problem
+
+Some upload paths can persist a generic MIME type (for example `application/octet-stream` / `application/x-empty`) even when the filename and/or content is a known format (PDF, images, etc.). This cascades into:
+
+- Preview status facets treating the document as unsupported (see unsupported MIME signals).
+- UI viewer selection treating the item as "unknown binary" and falling back to an unsupported preview state.
+
+## Design / Approach
+
+1. Prefer content sniffing first (most reliable).
+2. Only when the result is generic, retry detection with filename metadata (Tika `RESOURCE_NAME_KEY`) to allow extension-based inference.
+
+This keeps behavior safe by default while still fixing common “octet-stream but actually PDF” scenarios.
+
+### Generic MIME types
+
+We treat these as generic and eligible for filename fallback:
+
+- `application/octet-stream`
+- `binary/octet-stream`
+- `application/x-empty`
+
+## Implementation
+
+### Backend
+
+#### Filename-aware MIME detection with safe fallback
+
+- `ecm-core/src/main/java/com/ecm/core/service/ContentService.java`
+  - Added `detectMimeType(String contentId, String filename)`:
+    - First pass: `tika.detect(stream)`
+    - If generic: second pass `tika.detect(stream, metadata(filename))`
+    - If still generic: keep original result
+
+#### Apply to pipeline upload + versioning + legacy upload
+
+- `ecm-core/src/main/java/com/ecm/core/pipeline/processor/ContentStorageProcessor.java`
+  - Uses `contentService.detectMimeType(contentId, context.getOriginalFilename())` so pipeline uploads persist the normalized MIME type.
+- `ecm-core/src/main/java/com/ecm/core/service/VersionService.java`
+  - Uses filename-aware detection during check-in/version creation.
+- `ecm-core/src/main/java/com/ecm/core/controller/DocumentController.java`
+  - Legacy upload now sets the initial document MIME type from stored content detection (instead of trusting `MultipartFile#getContentType()`).
+
+### Frontend / E2E
+
+- `ecm-frontend/e2e/pdf-preview.spec.ts`
+  - Added Playwright test:
+    - Upload a PDF with multipart file `mimeType=application/octet-stream`
+    - Assert node `contentType` normalizes to `application/pdf`
+    - Assert the client PDF renderer shows `.react-pdf__Page__canvas`
+
+## Verification
+
+### Backend tests
+
+```bash
+cd ecm-core
+mvn -q test
+```
+
+Result: PASS (2026-02-13)
+
+### Playwright gate subset
+
+```bash
+cd ecm-frontend
+ECM_UI_URL=http://localhost:5500 ECM_API_URL=http://localhost:7700 \
+  npx playwright test \
+  e2e/ocr-queue-ui.spec.ts \
+  e2e/pdf-preview.spec.ts \
+  e2e/search-preview-status.spec.ts \
+  --project=chromium
+```
+
+Result: PASS (11 passed) (2026-02-13)
+
+## Notes / Follow-ups
+
+- If we want to hide "Retry failed previews" for PERMANENT failures entirely (not just block server-side), we should extend the UI bulk-action classification to incorporate PERMANENT vs TEMPORARY categories (Phase 4 Day 5/6).

--- a/docs/PHASE4_D3_PREVIEW_FAILURE_TAXONOMY_UX_20260213.md
+++ b/docs/PHASE4_D3_PREVIEW_FAILURE_TAXONOMY_UX_20260213.md
@@ -1,0 +1,121 @@
+# Phase 4 - Day 3: Preview Failure Taxonomy + UX Messaging (2026-02-13)
+
+## Goal
+
+Make preview failures actionable and consistent across:
+
+- Search Results (`/search-results`)
+- Advanced Search (`/search`)
+- Document Preview dialog
+- Upload dialog (post-upload status list)
+
+Specifically:
+
+- `TEMPORARY` failures should show retry actions (per-item + bulk).
+- `PERMANENT` failures should **not** show retry actions (retry is wasteful); show guidance instead.
+- `UNSUPPORTED` failures should show neutral status and no retry actions.
+
+## Background / Taxonomy
+
+Backend categorizes preview failures via:
+
+- `ecm-core/src/main/java/com/ecm/core/preview/PreviewFailureClassifier.java`
+
+Categories:
+
+- `UNSUPPORTED`: file type not supported, or known unsupported reasons, or generic MIME types (e.g. `application/octet-stream`).
+- `TEMPORARY`: transient infrastructure/service errors (timeouts, 5xx, connection resets/refusals).
+- `PERMANENT`: everything else (for example malformed PDFs / parse errors).
+
+Frontend must not guess "retryability" from `previewStatus=FAILED` alone.
+
+## UX Rules (Implemented)
+
+For effective preview status:
+
+1. `READY`
+   - Show "Preview ready".
+2. `PROCESSING` / `QUEUED`
+   - Show progress status.
+3. `UNSUPPORTED`
+   - Show "Preview unsupported".
+   - Hide retry actions.
+4. `FAILED`
+   - If retryable (`TEMPORARY` or transient-hint fallback): show retry + force rebuild.
+   - If permanent: hide retry actions and show guidance:
+     - Download the file and validate it.
+     - Upload a corrected version.
+
+Bulk actions:
+
+- "Retry failed previews" and "Force rebuild failed previews" only target **retryable** failures (never permanent).
+
+## Implementation Summary
+
+### Preview Utility Layer
+
+- `ecm-frontend/src/utils/previewStatusUtils.ts`
+  - Added `isTemporaryPreviewReason()` and `isRetryablePreviewFailure()`.
+  - `summarizeFailedPreviews()` now splits failures into:
+    - `retryableFailed`
+    - `permanentFailed`
+    - `unsupportedFailed`
+  - `getFailedPreviewMeta()` now labels:
+    - `Preview failed (temporary)`
+    - `Preview failed (permanent)`
+    - `Preview unsupported`
+- `ecm-frontend/src/utils/previewStatusUtils.test.ts`
+  - Added/updated coverage for PERMANENT vs TEMPORARY behavior.
+
+### UI Surfaces Updated
+
+- `ecm-frontend/src/pages/SearchResults.tsx`
+  - Per-item retry icons only show for `isRetryablePreviewFailure(...)`.
+  - Bulk retry targets only retryable failures.
+  - Preview issue summary includes "Permanent" count and message reflects permanent-only scenarios.
+- `ecm-frontend/src/pages/AdvancedSearchPage.tsx`
+  - Same behavior as Search Results (per-item + bulk).
+- `ecm-frontend/src/components/preview/DocumentPreview.tsx`
+  - FAILED banner:
+    - Retry actions only shown for retryable failures.
+    - PERMANENT uses an error severity + guidance copy.
+    - UNSUPPORTED uses info severity and hides actions.
+- `ecm-frontend/src/components/dialogs/UploadDialog.tsx`
+  - Post-upload "Queue preview"/"Force rebuild" actions hidden for PERMANENT failures.
+
+### E2E Updates
+
+- `ecm-frontend/e2e/search-preview-status.spec.ts`
+  - Updated the invalid PDF test to assert:
+    - preview endpoint returns `failureCategory=PERMANENT`
+    - UI hides per-item retry actions for that result
+    - bulk "Retry failed previews" is hidden when there are no retryable items in scope
+
+## Verification
+
+### Frontend Unit Tests
+
+```bash
+cd ecm-frontend
+CI=true npm test -- --watchAll=false
+```
+
+Result: **pass**.
+
+### Playwright E2E Gate Subset
+
+```bash
+cd ecm-frontend
+npx playwright test \
+  e2e/ocr-queue-ui.spec.ts \
+  e2e/pdf-preview.spec.ts \
+  e2e/search-preview-status.spec.ts \
+  --project=chromium
+```
+
+Result: **pass** (10 tests).
+
+### Notes
+
+- Playwright runs against the Docker-served UI at `http://localhost:5500`. After frontend changes, rebuild/recreate the `athena-ecm-frontend-1` container (for example via `bash scripts/restart-ecm.sh`) before running E2E.
+

--- a/docs/PHASE4_D4_BACKEND_PREVIEW_QUEUE_GUARDRAILS_20260213.md
+++ b/docs/PHASE4_D4_BACKEND_PREVIEW_QUEUE_GUARDRAILS_20260213.md
@@ -1,0 +1,116 @@
+# Phase 4 - Day 4: Backend Preview Queue Guardrails + Queue Status Message (2026-02-13)
+
+## Goal
+
+1. Add server-side guardrails so `POST /api/v1/documents/{id}/preview/queue` does not wastefully retry **PERMANENT** preview failures unless `force=true`.
+2. Make the queue endpoint self-explanatory by returning a short `message` (aligned with OCR queue semantics).
+3. Keep UI consistent: when an action is hidden in the frontend, the backend should still be safe-by-default.
+
+## Background
+
+The backend already classifies preview failures via:
+
+- `ecm-core/src/main/java/com/ecm/core/preview/PreviewFailureClassifier.java`
+
+Categories:
+
+- `UNSUPPORTED`: known unsupported types/reasons (including generic MIME types like `application/octet-stream`).
+- `TEMPORARY`: transient infra/service errors (timeouts, 5xx, connection reset/refused).
+- `PERMANENT`: everything else (for example malformed PDFs / parse errors).
+
+Day 3 implemented UI gating so PERMANENT/UNSUPPORTED failures do not show retry actions. Day 4 adds server-side enforcement so the API is robust for future UIs and direct API callers.
+
+## Changes
+
+### Backend: Guardrails + Message Field
+
+Updated:
+
+- `ecm-core/src/main/java/com/ecm/core/preview/PreviewQueueService.java`
+
+Key behaviors (when `force=false`):
+
+- `READY` -> `queued=false`, `message="Preview already up to date"`
+- `UNSUPPORTED` -> `queued=false`, `message="Preview unsupported"`
+- `FAILED` + classifier `UNSUPPORTED` -> `queued=false`, `message="Preview unsupported"`
+- `FAILED` + classifier `PERMANENT` -> `queued=false`, `message="Preview failed permanently; use force=true to rebuild"`
+- Existing queued job -> `queued=true`, `message="Preview already queued"`
+- Newly queued job -> `queued=true`, `message="Preview queued"`
+
+Also:
+
+- `PreviewQueueStatus` now includes a `message` field (aligned with `OcrQueueStatus`).
+- Redis backend path returns the same message semantics.
+
+Tests updated/added:
+
+- `ecm-core/src/test/java/com/ecm/core/preview/PreviewQueueServiceTest.java`
+  - Verifies unsupported skip message.
+  - Verifies PERMANENT failures are blocked without force.
+  - Verifies TEMPORARY failures are allowed without force and transition to PROCESSING.
+
+### Frontend: Use `message` + Fix Upload Force Bug
+
+Updated queue toasts to prefer the server-provided `message`:
+
+- `ecm-frontend/src/pages/SearchResults.tsx`
+- `ecm-frontend/src/pages/AdvancedSearchPage.tsx`
+- `ecm-frontend/src/components/preview/DocumentPreview.tsx`
+- `ecm-frontend/src/components/dialogs/UploadDialog.tsx`
+
+Type updated:
+
+- `ecm-frontend/src/services/nodeService.ts` (`PreviewQueueStatus.message`)
+
+Bug fix:
+
+- `ecm-frontend/src/components/dialogs/UploadDialog.tsx`
+  - Previously posted `{ force }` in the request body; backend expects query param `force`.
+  - Switched to `nodeService.queuePreview(nodeId, force)` so Force Rebuild actually forces.
+
+## Verification
+
+### Backend Tests
+
+```bash
+cd ecm-core
+mvn -q test
+```
+
+Result: **pass**.
+
+### Frontend Unit Tests
+
+```bash
+cd ecm-frontend
+CI=true npm test -- --watchAll=false
+```
+
+Result: **pass** (13 suites / 70 tests).
+
+### Playwright E2E Gate Subset
+
+```bash
+cd ecm-frontend
+npx playwright test \
+  e2e/ocr-queue-ui.spec.ts \
+  e2e/pdf-preview.spec.ts \
+  e2e/search-preview-status.spec.ts \
+  --project=chromium
+```
+
+Result: **pass** (10 tests).
+
+### Runtime Note (E2E Target)
+
+Playwright runs against the Docker-served UI at `http://localhost:5500`. After code changes, rebuild/recreate the containers (for example):
+
+```bash
+bash scripts/restart-ecm.sh
+```
+
+## Follow-Ups
+
+- Day 2 (planned): MIME normalization/sniffing for `application/octet-stream` uploads (reduces false UNSUPPORTED).
+- Optional: consider returning `previewStatus=PROCESSING` in the queue response when a job is actually queued (currently the UI treats queued status as PROCESSING client-side).
+

--- a/docs/PHASE4_D5_OBSERVABILITY_DIAGNOSTICS_20260213.md
+++ b/docs/PHASE4_D5_OBSERVABILITY_DIAGNOSTICS_20260213.md
@@ -1,0 +1,113 @@
+# Phase 4 - Day 5: Preview Observability + Diagnostics (2026-02-13)
+
+## Goal
+
+Make preview generation behavior observable and easier to debug:
+
+1. Metrics to understand volumes of `READY`/`FAILED`/`UNSUPPORTED` by MIME type and failure category.
+2. Logs that record a structured outcome for failures without flooding the logs.
+3. Admin-only diagnostics endpoint to sample recent failures with derived categories.
+
+## Changes
+
+### Backend: Metrics + Logs
+
+Updated:
+
+- `ecm-core/src/main/java/com/ecm/core/preview/PreviewService.java`
+
+Behavior:
+
+- Records a counter `preview_generation_total` with tags:
+  - `status`: `READY|FAILED|UNSUPPORTED|...`
+  - `category`: `TEMPORARY|PERMANENT|UNSUPPORTED|NONE`
+  - `mimeType`: normalized to lowercase and stripped of `; charset=...`
+- Writes one structured log line for non-`READY` outcomes:
+  - `UNSUPPORTED` at `INFO`
+  - `FAILED` at `WARN`
+
+Example log:
+
+```
+Preview generation outcome: documentId=<uuid> status=UNSUPPORTED category=UNSUPPORTED mimeType=application/octet-stream reason=...
+```
+
+### Backend: Recent Failures API
+
+Added:
+
+- `ecm-core/src/main/java/com/ecm/core/controller/PreviewDiagnosticsController.java`
+  - `GET /api/v1/preview/diagnostics/failures?limit=50`
+  - Admin-only: `@PreAuthorize("hasRole('ADMIN')")`
+
+Response is a list of:
+
+- `id`, `name`, `path`
+- `mimeType`
+- `previewStatus`
+- `previewFailureReason`
+- `previewFailureCategory` (derived using `PreviewFailureClassifier`)
+- `previewLastUpdated`
+
+Repository support:
+
+- `ecm-core/src/main/java/com/ecm/core/repository/DocumentRepository.java`
+  - `findRecentPreviewFailures(List<PreviewStatus> statuses, Pageable pageable)`
+
+Tests:
+
+- `ecm-core/src/test/java/com/ecm/core/controller/PreviewDiagnosticsControllerSecurityTest.java`
+  - Verifies admin-only access and limit clamping.
+
+## Verification
+
+### Backend Unit/Integration Tests
+
+```bash
+cd ecm-core
+mvn -q test
+```
+
+Result: PASS (2026-02-13)
+
+### Runtime Smoke (API + Metrics + Logs)
+
+1) Get an admin token:
+
+```bash
+./scripts/get-token.sh admin admin
+```
+
+2) List recent failures:
+
+```bash
+curl -fsS -H "Authorization: Bearer $(cat tmp/admin.access_token)" \
+  "http://localhost:7700/api/v1/preview/diagnostics/failures?limit=5" | jq .
+```
+
+3) Trigger a preview to emit a metric + log (use an UNSUPPORTED file):
+
+```bash
+DOC_ID="<some-document-id>"
+curl -fsS -H "Authorization: Bearer $(cat tmp/admin.access_token)" \
+  "http://localhost:7700/api/v1/documents/${DOC_ID}/preview" | jq .
+```
+
+4) Confirm the metric exists:
+
+```bash
+curl -fsS -H "Authorization: Bearer $(cat tmp/admin.access_token)" \
+  http://localhost:7700/actuator/prometheus | rg '^preview_generation_total' | head
+```
+
+5) Confirm a structured log was emitted:
+
+```bash
+docker logs --tail 200 athena-ecm-core-1 | rg "Preview generation outcome" | tail
+```
+
+## Notes
+
+- The counter is only created after the first preview outcome is recorded (Micrometer behavior).
+- `UNSUPPORTED` is logged at `INFO` to avoid treating permanent unsupported formats as operational failures.
+

--- a/docs/PHASE4_D6_AUTOMATION_COVERAGE_EXPANSION_20260213.md
+++ b/docs/PHASE4_D6_AUTOMATION_COVERAGE_EXPANSION_20260213.md
@@ -1,0 +1,41 @@
+# Phase 4 - Day 6: Automation Coverage Expansion (2026-02-13)
+
+## Goal
+
+Lock in the Phase 4 preview semantics with automation so regressions are caught early:
+
+- Octet-stream mislabeled PDFs normalize correctly and preview renders.
+- Permanent preview failures do not surface retry actions.
+- CAD preview failures are classified consistently and the UI gates actions based on retryability.
+
+## Changes
+
+### Playwright E2E: Preview Status + CAD Coverage
+
+Updated:
+
+- `ecm-frontend/e2e/search-preview-status.spec.ts`
+
+Additions / hardening:
+
+- Permanent-failure search is now alpha-tokenized to avoid fuzzy matches with historical E2E artifacts.
+- Added DWG upload helper that tolerates `400` from text extraction (Tika DWG parser) as long as a `documentId` is returned.
+- Added CAD preview scenario:
+  - Calls `GET /api/v1/documents/{id}/preview`
+  - Asserts:
+    - If CAD is disabled/unconfigured -> `UNSUPPORTED` and no retry actions
+    - If CAD renderer is configured but unhealthy -> `FAILED` and action gating matches `TEMPORARY` vs `PERMANENT`
+
+## Verification
+
+```bash
+cd ecm-frontend
+npx playwright test \
+  e2e/ocr-queue-ui.spec.ts \
+  e2e/pdf-preview.spec.ts \
+  e2e/search-preview-status.spec.ts \
+  --project=chromium
+```
+
+Result: PASS (12 passed) (2026-02-13)
+

--- a/docs/PHASE4_D7_REGRESSION_GATE_RELEASE_NOTES_20260213.md
+++ b/docs/PHASE4_D7_REGRESSION_GATE_RELEASE_NOTES_20260213.md
@@ -1,0 +1,41 @@
+# Phase 4 - Day 7: Regression Gate + Release Notes (2026-02-13)
+
+## What Shipped (Phase 4 Summary)
+
+Phase 4 focused on preview reliability, actionable failure semantics, and operator ergonomics.
+
+- Day 1: Retry classification hardening (avoid wasteful retries for permanent failures; CAD disabled/unconfigured -> UNSUPPORTED)
+  - `docs/PHASE4_D1_PREVIEW_RETRY_CLASSIFICATION_20260213.md`
+- Day 2: MIME type normalization for `application/octet-stream` (content sniff + filename fallback)
+  - `docs/PHASE4_D2_MIME_TYPE_NORMALIZATION_20260213.md`
+- Day 3: Failure taxonomy + UX messaging consistency (Search / Advanced Search / Preview dialog)
+  - `docs/PHASE4_D3_PREVIEW_FAILURE_TAXONOMY_UX_20260213.md`
+- Day 4: Backend guardrails for preview queue + message field parity
+  - `docs/PHASE4_D4_BACKEND_PREVIEW_QUEUE_GUARDRAILS_20260213.md`
+- Day 5: Observability + admin diagnostics endpoint
+  - `docs/PHASE4_D5_OBSERVABILITY_DIAGNOSTICS_20260213.md`
+- Day 6: Automation coverage expansion (lock semantics with Playwright)
+  - `docs/PHASE4_D6_AUTOMATION_COVERAGE_EXPANSION_20260213.md`
+
+## Regression Gate
+
+Run the weekly subset gate (serial, chromium):
+
+```bash
+cd ecm-frontend
+npx playwright test --workers=1 \
+  e2e/ui-smoke.spec.ts \
+  e2e/search-view.spec.ts \
+  e2e/search-preview-status.spec.ts \
+  e2e/pdf-preview.spec.ts \
+  e2e/ocr-queue-ui.spec.ts \
+  --project=chromium
+```
+
+Result: PASS (24 passed) (2026-02-13)
+
+## Notes
+
+- The gate targets the Docker-served UI at `http://localhost:5500` (auto-detected by the E2E helpers when `ECM_UI_URL` is not set).
+- ClamAV may report unhealthy/unavailable in local dev; the antivirus E2E case tolerates that startup behavior and still validates the rejection flow when available.
+

--- a/docs/PHASE54_PREVIEW_DIAGNOSTICS_UI_DEV_20260213.md
+++ b/docs/PHASE54_PREVIEW_DIAGNOSTICS_UI_DEV_20260213.md
@@ -1,0 +1,69 @@
+# Phase 54 - Admin Preview Diagnostics UI (Dev) - 2026-02-13
+
+## Goals
+
+- Give admins a single place to triage **recent preview failures** (FAILED/UNSUPPORTED).
+- Make the next action obvious:
+  - open the item in Advanced Search
+  - retry / force rebuild **only** when retryable (TEMPORARY / transient hints)
+
+## Backend Contract (Existing)
+
+- Admin sample endpoint:
+  - `GET /api/v1/preview/diagnostics/failures?limit=50`
+  - Auth: `ROLE_ADMIN`
+  - Returns a list of:
+    - `id`
+    - `name`
+    - `path`
+    - `mimeType`
+    - `previewStatus`
+    - `previewFailureCategory`
+    - `previewFailureReason`
+    - `previewLastUpdated`
+- Queue actions:
+  - `POST /api/v1/documents/{id}/preview/queue?force=false` (retry)
+  - `POST /api/v1/documents/{id}/preview/queue?force=true` (force rebuild)
+
+## Frontend Changes
+
+### Route + Access Control
+
+- New admin-only route: `/admin/preview-diagnostics`
+  - Guarded via `PrivateRoute requiredRoles={['ROLE_ADMIN']}`
+
+### Navigation
+
+- Added menu entry:
+  - `MainLayout` -> Admin -> **Preview Diagnostics**
+
+### Page UX
+
+- Table of recent failure samples with:
+  - quick filter (`name`, `path`, `mimeType`, status/category/reason)
+  - limit selector (25/50/100/200)
+  - summary chips:
+    - total, retryable, permanent, unsupported
+- Per-row actions:
+  - open in Advanced Search (`/search?q=<name>`)
+  - retry preview / force rebuild (disabled when not retryable)
+
+### Retryability Rules
+
+Uses shared logic in `utils/previewStatusUtils.ts`:
+
+- UNSUPPORTED:
+  - category contains `UNSUPPORTED`, or
+  - reason contains “not supported/unsupported …”, or
+  - mime type is known-unsupported (e.g. `application/octet-stream`)
+- Retryable:
+  - category is `TEMPORARY`, or
+  - reason contains transient hints (timeout/502/503/504/etc)
+
+## Files Added/Updated
+
+- `ecm-frontend/src/App.tsx`
+- `ecm-frontend/src/components/layout/MainLayout.tsx`
+- `ecm-frontend/src/pages/PreviewDiagnosticsPage.tsx`
+- `ecm-frontend/src/services/previewDiagnosticsService.ts`
+

--- a/docs/PHASE54_PREVIEW_DIAGNOSTICS_UI_VERIFICATION_20260213.md
+++ b/docs/PHASE54_PREVIEW_DIAGNOSTICS_UI_VERIFICATION_20260213.md
@@ -1,0 +1,57 @@
+# Phase 54 - Admin Preview Diagnostics UI (Verification) - 2026-02-13
+
+## Automated Checks
+
+### 1) UI E2E (Mocked API, No Docker Required)
+
+This test validates:
+- page renders with E2E auth bypass
+- summary chips match sample data
+- filter works
+- retry is enabled only for retryable failures
+
+Command:
+
+```bash
+cd ecm-frontend
+ECM_UI_URL=http://localhost:3000 npx playwright test e2e/admin-preview-diagnostics.mock.spec.ts --project=chromium --workers=1
+```
+
+Status: PASS (2026-02-13)
+
+Notes:
+- To avoid CRA dev-server rebuilds (and deep-link routing issues in simple static servers), you can serve the production build and run the test against it:
+
+```bash
+cd ecm-frontend
+(cd build && python3 -m http.server 5500)
+ECM_UI_URL=http://localhost:5500 npx playwright test e2e/admin-preview-diagnostics.mock.spec.ts --project=chromium --workers=1
+```
+
+### 2) UI + API E2E (Real Backend Required)
+
+This test validates:
+- create folder under `Documents`
+- upload an `application/octet-stream` `.bin`
+- backend marks preview as UNSUPPORTED
+- diagnostics endpoint returns the item
+- UI page shows it and filter finds it
+
+Command:
+
+```bash
+cd ecm-frontend
+ECM_UI_URL=http://localhost:3000 ECM_API_URL=http://localhost:7700 npx playwright test e2e/admin-preview-diagnostics.spec.ts --project=chromium --workers=1
+```
+
+## Manual Smoke
+
+1. Login as `admin`.
+2. Open `/admin/preview-diagnostics`.
+3. Confirm you see recent failures, and that **Retry/Force rebuild** are disabled for UNSUPPORTED/PERMANENT.
+4. Click the search icon to open the item in Advanced Search.
+
+## Results (2026-02-13)
+
+- Mocked E2E: ✅ `admin-preview-diagnostics.mock.spec.ts`
+- Real backend E2E: ⏳ pending (requires Docker stack running at `http://localhost:7700`)

--- a/docs/PHASE55_PREVIEW_DIAGNOSTICS_HARDENING_DEV_20260214.md
+++ b/docs/PHASE55_PREVIEW_DIAGNOSTICS_HARDENING_DEV_20260214.md
@@ -1,0 +1,62 @@
+# Phase 55 - Preview Diagnostics Hardening (Dev) - 2026-02-14
+
+## Goals
+
+- Reduce admin triage friction on preview failures:
+  - fewer copy/paste steps
+  - faster navigation from a failure sample to the underlying node
+- Improve deep links so Advanced Search opens with the correct preview-status filter applied.
+
+## Changes
+
+### 1) Advanced Search Deep Link Includes `previewStatus`
+
+Preview Diagnostics "Open in Advanced Search" now navigates to:
+
+- `/search?q=<name>&previewStatus=FAILED|UNSUPPORTED`
+
+Rationale:
+- admins immediately see failure-scoped results (instead of a broad name search),
+- aligns with Advanced Search UX (preview-status facet actions + retry/rebuild tooling).
+
+### 2) Copy Document Id (Per Row)
+
+New per-row action: **Copy document id**
+
+- Uses `navigator.clipboard.writeText(item.id)`
+- Shows toast:
+  - success: `Document id copied`
+  - failure: `Failed to copy document id`
+
+### 3) Open Parent Folder (Per Row)
+
+New per-row action: **Open parent folder**
+
+Behavior:
+
+1. Compute a parent folder path from `item.path` by removing the last segment.
+   - Example: `/Root/Documents/foo/bar.pdf` -> `/Root/Documents/foo`
+2. Resolve folder id:
+   - `GET /api/v1/folders/path?path=<parentPath>`
+3. Navigate to:
+   - `/browse/<folderId>`
+
+Guardrails:
+- If `item.path` is missing/unparseable, the action is disabled.
+
+### 4) Hook Lint Cleanup
+
+`loadFailures` is memoized with `useCallback` to avoid stale closures and silence hooks lint warnings.
+
+## Files Updated
+
+- `ecm-frontend/src/pages/PreviewDiagnosticsPage.tsx`
+- `ecm-frontend/e2e/admin-preview-diagnostics.mock.spec.ts`
+
+## Notes / Limitations
+
+- Integration E2E still recommended (requires backend stack) to validate:
+  - real diagnostics endpoint payloads
+  - real folder-path resolution behavior
+- Parent-folder navigation currently targets the folder (not auto-opening the document preview inside that folder).
+

--- a/docs/PHASE55_PREVIEW_DIAGNOSTICS_HARDENING_VERIFICATION_20260214.md
+++ b/docs/PHASE55_PREVIEW_DIAGNOSTICS_HARDENING_VERIFICATION_20260214.md
@@ -1,0 +1,47 @@
+# Phase 55 - Preview Diagnostics Hardening (Verification) - 2026-02-14
+
+## Automated Checks
+
+### 1) UI E2E (Mocked API, No Docker Required)
+
+This spec now validates:
+
+- page renders with E2E auth bypass
+- summary chips match sample data
+- filter works
+- retry is enabled only for retryable failures
+- **copy document id** calls clipboard (clipboard is stubbed to avoid OS permission flakiness)
+- **open in Advanced Search** includes `previewStatus=FAILED` and `q=<name>`
+- **open parent folder** resolves folder by path and navigates to `/browse/<folderId>`
+
+Command (static build server, recommended for near-full disk environments):
+
+```bash
+cd ecm-frontend
+npm run build
+(python3 -m http.server 5500 --directory build)
+ECM_UI_URL=http://localhost:5500 npx playwright test e2e/admin-preview-diagnostics.mock.spec.ts --project=chromium --workers=1
+```
+
+Status: PASS (2026-02-14)
+
+### 2) UI + API E2E (Real Backend Required)
+
+Integration spec (not re-run in this environment; requires Docker stack + backend at `http://localhost:7700`):
+
+```bash
+cd ecm-frontend
+ECM_UI_URL=http://localhost:3000 ECM_API_URL=http://localhost:7700 npx playwright test e2e/admin-preview-diagnostics.spec.ts --project=chromium --workers=1
+```
+
+Status: ⏳ pending (backend unavailable)
+
+## Manual Smoke
+
+1. Login as `admin`.
+2. Open `/admin/preview-diagnostics`.
+3. Confirm:
+   - **Copy document id** copies a UUID to clipboard.
+   - **Open parent folder** navigates to the containing folder.
+   - **Open in Advanced Search** opens with a preview-status filter applied.
+

--- a/docs/PHASE56_PERMISSION_SET_UX_PARITY_DEV_20260214.md
+++ b/docs/PHASE56_PERMISSION_SET_UX_PARITY_DEV_20260214.md
@@ -1,0 +1,87 @@
+# Phase 56 - Permission-Set UX Parity (Dev) - 2026-02-14
+
+## Goal
+
+Make Alfresco-style permission presets obvious during permissions triage:
+
+- Coordinator
+- Editor
+- Contributor
+- Consumer
+
+So admins can quickly understand whether a principal is on a known preset or a custom mix.
+
+## Scope / Non-Goals
+
+In scope:
+
+- UI-only improvements in the Permissions dialog.
+- Works with existing backend permission set endpoints (no API changes).
+- Adds Playwright mocked E2E coverage (no backend required).
+
+Not in scope:
+
+- Changing backend permission semantics or templates.
+- Introducing new permission presets (we display what backend exposes).
+
+## What Changed
+
+### 1) Preset Legend (Help Text)
+
+`PermissionsDialog` now shows a compact legend:
+
+- "Permission presets (Alfresco-style)"
+- Chips for each preset with tooltip:
+  - description
+  - included permissions
+
+This provides in-context help without requiring a separate doc lookup.
+
+### 2) "Effective preset" Column
+
+The permissions grid now includes an **Effective preset** column per principal.
+
+Behavior:
+
+- If the principal's allowed permissions exactly match a preset:
+  - show the preset name (green chip)
+- Otherwise:
+  - show `Custom` + `Closest: <Preset>`
+  - tooltip shows:
+    - preset description
+    - missing permissions (what the preset would add)
+
+### Matching Rule (Closest Preset)
+
+To keep the output intuitive, we choose the **smallest preset that fully contains the principal's current allows**:
+
+- find presets where `presetPermissions ⊇ allowedPermissions`
+- choose the one with the fewest missing permissions (`presetPermissions - allowedPermissions`)
+
+This avoids surprising results like suggesting `Consumer` for `READ+WRITE` (which is closer by symmetric-diff but not conceptually aligned).
+
+### Data Sources / API Contract
+
+We rely on existing endpoints (already used by the dialog):
+
+- `GET /api/v1/security/permission-sets/metadata`
+  - provides `label`, `description`, `order`, `permissions[]`
+- `GET /api/v1/security/permission-sets`
+  - provides a fallback mapping `{ [setName]: PermissionType[] }` if metadata is unavailable
+
+The backend canonical reference remains `ecm-core/src/main/java/com/ecm/core/entity/PermissionSet.java`.
+
+### UX Notes
+
+- “Effective preset” is derived from the **current ALLOW grants** shown in the grid.
+- If no preset fully contains the allowed set, we show `Custom` without a closest preset (tooltip shows the extra allowed permissions).
+- The “Preset” dropdown (apply preset) is unchanged; “Effective preset” is informational and helps triage.
+
+## Files Updated / Added
+
+- `ecm-frontend/src/components/dialogs/PermissionsDialog.tsx`
+- `ecm-frontend/e2e/permissions-dialog-presets.mock.spec.ts`
+
+## Related
+
+- Verification: `docs/PHASE56_PERMISSION_SET_UX_PARITY_VERIFICATION_20260214.md`

--- a/docs/PHASE56_PERMISSION_SET_UX_PARITY_VERIFICATION_20260214.md
+++ b/docs/PHASE56_PERMISSION_SET_UX_PARITY_VERIFICATION_20260214.md
@@ -1,0 +1,70 @@
+# Phase 56 - Permission-Set UX Parity (Verification) - 2026-02-14
+
+## Summary
+
+Verification target:
+
+- Permissions dialog shows:
+  - Preset legend ("Permission presets (Alfresco-style)")
+  - Per-principal “Effective preset” column
+  - Correct labeling for exact preset vs custom subset ("Custom (Closest: Editor)")
+
+Primary verification method:
+
+- Playwright mocked E2E (no backend required)
+
+## Preconditions
+
+- Node/npm available (for `npx`)
+- Frontend deps installed in `ecm-frontend/`
+
+## Automated Verification (Mocked E2E)
+
+### 1) Build UI
+
+```bash
+cd ecm-frontend
+npm run build
+```
+
+### 2) Serve static build
+
+```bash
+python3 -m http.server 5500 --directory build
+```
+
+Keep that process running in a separate terminal.
+
+### 3) Run Playwright test
+
+```bash
+cd ecm-frontend
+ECM_UI_URL=http://localhost:5500 npx playwright test \
+  e2e/permissions-dialog-presets.mock.spec.ts \
+  --project=chromium --workers=1
+```
+
+Expected assertions:
+
+- The dialog renders legend text:
+  - `Permission presets (Alfresco-style)`
+- Users tab rows:
+  - `preset-editor` => `Editor`
+  - `custom-user` => `Custom` + `Closest: Editor`
+  - `preset-consumer` => `Consumer`
+- Groups tab rows:
+  - `contributors` => `Contributor`
+
+Result:
+
+- PASS (Playwright mocked E2E)
+
+## Manual Spot Check (Optional)
+
+1. Open the UI.
+2. Navigate to any node in File Browser.
+3. Open actions menu => `Permissions`.
+4. Confirm:
+   - The preset legend appears above the Users/Groups tabs.
+   - “Effective preset” column shows either a preset chip or `Custom` + `Closest: ...`.
+

--- a/docs/PHASE57_AUDIT_FILTER_EXPORT_UX_DEV_20260214.md
+++ b/docs/PHASE57_AUDIT_FILTER_EXPORT_UX_DEV_20260214.md
@@ -1,0 +1,84 @@
+# Phase 57 - Audit: Filtered Explorer + Export Presets UX (Admin Dashboard)
+
+Date: 2026-02-14
+
+## Goal
+
+Make audit investigation and export operationally smooth (Alfresco-style ergonomics):
+
+- Filter audit logs by `user`, `eventType`, `category`, `nodeId`, and time range.
+- Persist filters in the URL (shareable deep links).
+- Export CSV with stable, descriptive filenames (date range + filters summary).
+
+## UX Summary
+
+Location: Admin Dashboard (tab "System Dashboard") audit controls.
+
+- Filters:
+  - `User` (freeSolo autocomplete)
+  - `Event Type` (freeSolo autocomplete; displays human label but stores event code)
+  - `Category` (select)
+  - `Node ID` (UUID)
+  - `From` / `To` (custom range)
+- Actions:
+  - `Filter Logs` updates URL query params and fetches filtered results.
+  - `Reset` clears filters and restores "recent" logs.
+  - `Export CSV` uses presets or a custom range and downloads a CSV with a stable filename.
+
+## Key Design Decisions
+
+### 1) Shareable URL Filters
+
+We persist audit filters under dedicated query keys to avoid collisions with existing search routing:
+
+- `auditUser`
+- `auditEventType`
+- `auditCategory`
+- `auditNodeId`
+- `auditFrom`
+- `auditTo`
+
+Implementation: `syncAuditUrlFilters(...)` updates the current location with `navigate(..., { replace: true })`.
+
+To avoid a fetch loop when we update the URL internally, a `suppressAuditUrlSyncRef` flag is used to ignore the next `location.search` effect run.
+
+### 2) Event Type Normalization (Fix: label vs code mismatch)
+
+MUI `Autocomplete` with `getOptionLabel()` can emit the *formatted label* (e.g., "Node Created") via `onInputChange`, which would then be sent to the API as `eventType=Node Created` and not match backend expectations.
+
+We normalize event types to codes (e.g., `NODE_CREATED`) everywhere that matters:
+
+- UI input handler: `onInputChange` stores `normalizeAuditEventType(value)` so the state stays code-based.
+- URL sync: persist normalized `auditEventType`.
+- Audit search request: send normalized `eventType`.
+- Export request + export filename: use normalized `eventType`.
+- URL hydration: normalize `auditEventType` from the URL before requesting filtered logs.
+
+`normalizeAuditEventType(...)` behavior:
+
+- If input matches a known code, keep it.
+- Else canonicalize: `trim().toUpperCase().replace(/\\s+/g, '_')`
+- If the canonical form matches a known code, use it.
+- If input matches a displayed label for a known code, map back to that code.
+- Otherwise, return the canonical form.
+
+### 3) Stable Export Filenames
+
+Export downloads now use `buildAuditExportFilename(...)` to generate:
+
+`audit_logs_<dateLabel>_preset-<preset>_user-<user>_event-<eventType>_cat-<category>_node-<uuid8>.csv`
+
+Segments are sanitized for filesystem safety and truncated to avoid excessive length.
+
+## Code Touchpoints
+
+- Admin dashboard audit UX + export:
+  - `ecm-frontend/src/pages/AdminDashboard.tsx`
+- Mocked E2E coverage:
+  - `ecm-frontend/e2e/admin-audit-filter-export.mock.spec.ts`
+
+## Notes / Out of Scope
+
+- This slice does not change backend audit endpoint contracts.
+- Integration E2E coverage (full Docker stack) can be added later; the mocked spec keeps UI verification unblocked when Docker is unavailable.
+

--- a/docs/PHASE57_AUDIT_FILTER_EXPORT_UX_VERIFICATION_20260214.md
+++ b/docs/PHASE57_AUDIT_FILTER_EXPORT_UX_VERIFICATION_20260214.md
@@ -1,0 +1,58 @@
+# Phase 57 - Audit: Filtered Explorer + Export Presets UX (Verification)
+
+Date: 2026-02-14
+
+## What We Verify
+
+- Audit filters persist in the URL (shareable).
+- Filtered audit search sends normalized `eventType` codes (e.g., `NODE_CREATED`).
+- Export triggers a download with a stable filename that includes:
+  - date range label
+  - `user-...`
+  - `event-...`
+  - `cat-...`
+  - `node-<uuid8>`
+
+## Mocked E2E (No Backend Required)
+
+This uses a static build server and Playwright route mocking.
+
+### Build + Serve
+
+```bash
+cd ecm-frontend
+npm run build
+python3 -m http.server 5500 --directory build
+```
+
+### Run Targeted Test
+
+```bash
+cd ecm-frontend
+ECM_UI_URL=http://localhost:5500 npx playwright test \
+  e2e/admin-audit-filter-export.mock.spec.ts \
+  --project=chromium --workers=1
+```
+
+### Run Mocked Regression Subset
+
+```bash
+cd ecm-frontend
+ECM_UI_URL=http://localhost:5500 npx playwright test \
+  e2e/admin-preview-diagnostics.mock.spec.ts \
+  e2e/permissions-dialog-presets.mock.spec.ts \
+  e2e/admin-audit-filter-export.mock.spec.ts \
+  --project=chromium --workers=1
+```
+
+## Expected Results
+
+- All Playwright specs pass.
+- The audit search request includes `eventType=NODE_CREATED` (not a human label like "Node Created").
+- Download filename contains:
+  - `audit_logs_YYYYMMDD_to_YYYYMMDD`
+  - `user-<username>`
+  - `event-<EVENT_CODE>`
+  - `cat-<CATEGORY>`
+  - `node-<uuid8>`
+

--- a/docs/PHASE58_VERSION_HISTORY_PAGING_UX_DEV_20260214.md
+++ b/docs/PHASE58_VERSION_HISTORY_PAGING_UX_DEV_20260214.md
@@ -1,0 +1,50 @@
+# Phase 58 - Version History: Paging UX + Major-Only Toggle (Mocked Coverage)
+
+Date: 2026-02-14
+
+## Goal
+
+Ensure the Version History dialog remains usable and regression-protected:
+
+- Version history is fetched via the paged endpoint (no "load everything" behavior).
+- Operators can toggle "Major versions only".
+- Paging UX is present via an explicit "Load more" control.
+
+This phase focuses on **automation coverage** (mocked Playwright) to keep the feature stable even when backend/Docker is unavailable.
+
+## UX Summary
+
+From the file browser context menu for a document:
+
+1. Open `Version History`
+2. View latest versions (newest first)
+3. Use:
+   - `Load more` to fetch older versions (paged)
+   - `Major versions only` to switch to a major-only view
+
+## API / Data Flow
+
+Frontend calls:
+
+- `GET /api/v1/documents/:id/versions/paged?page=<n>&size=<k>&majorOnly=<bool>`
+
+The UI appends additional pages when `Load more` is used.
+
+## Automation
+
+Added a mocked E2E spec that:
+
+- Boots the file browser from `/` (static build safe).
+- Opens the document action menu -> `Version History`.
+- Asserts:
+  - initial page renders
+  - `Load more` triggers a second page and appends older versions
+  - enabling `Major versions only` switches to major-only results
+
+### Code Touchpoints
+
+- Version history UI:
+  - `ecm-frontend/src/components/dialogs/VersionHistoryDialog.tsx`
+- Mocked E2E:
+  - `ecm-frontend/e2e/version-history-paging-major-only.mock.spec.ts`
+

--- a/docs/PHASE58_VERSION_HISTORY_PAGING_UX_VERIFICATION_20260214.md
+++ b/docs/PHASE58_VERSION_HISTORY_PAGING_UX_VERIFICATION_20260214.md
@@ -1,0 +1,37 @@
+# Phase 58 - Version History: Paging UX + Major-Only Toggle (Verification)
+
+Date: 2026-02-14
+
+## What We Verify
+
+- Version History dialog loads via the paged versions endpoint.
+- `Load more` appends older versions (requests next page).
+- `Major versions only` toggles the query to major-only results.
+
+## Mocked E2E (No Backend Required)
+
+### Build + Serve
+
+```bash
+cd ecm-frontend
+npm run build
+python3 -m http.server 5500 --directory build
+```
+
+### Run Test
+
+```bash
+cd ecm-frontend
+ECM_UI_URL=http://localhost:5500 npx playwright test \
+  e2e/version-history-paging-major-only.mock.spec.ts \
+  --project=chromium --workers=1
+```
+
+## Expected Results
+
+- Playwright spec passes.
+- The mocked `/documents/:id/versions/paged` handler observes:
+  - `page=0` on initial open
+  - `page=1` after `Load more`
+  - `majorOnly=true` after enabling "Major versions only"
+

--- a/docs/PHASE59_SEARCH_SUGGESTIONS_SAVED_SEARCH_UX_DEV_20260214.md
+++ b/docs/PHASE59_SEARCH_SUGGESTIONS_SAVED_SEARCH_UX_DEV_20260214.md
@@ -1,0 +1,60 @@
+# Phase 59 - Search: "Did You Mean" + Save Search Convenience (Mocked Coverage)
+
+Date: 2026-02-14
+
+## Goal
+
+Protect two high-frequency search ergonomics features with CLI automation:
+
+- Spellcheck suggestions surface as "Did you mean ..." and are clickable.
+- Advanced Search criteria can be saved as a Saved Search with minimal friction.
+
+This phase focuses on a **mocked Playwright E2E** so UI verification stays unblocked when Docker/backends are unavailable.
+
+## UX Summary
+
+### Spellcheck Suggestions
+
+On `Search Results`, when a name query likely contains a typo:
+
+- UI shows "Checking spelling suggestions…" (while loading).
+- UI shows "Did you mean <suggestion>" with clickable suggestion buttons.
+- Clicking a suggestion re-runs the search with the corrected query.
+
+### Save Search
+
+From `Advanced Search`:
+
+- Fill at least one criterion (e.g., `Name contains`).
+- Click `Save Search`
+- Enter a name and click `Save` to create a Saved Search.
+
+## API / Data Flow
+
+- Search (simple full-text fast path):
+  - `GET /api/v1/search?q=<query>&page=<n>&size=<k>[...]`
+- Spellcheck:
+  - `GET /api/v1/search/spellcheck?q=<query>&limit=<n>`
+- Saved searches:
+  - `GET /api/v1/search/saved`
+  - `POST /api/v1/search/saved`
+
+## Automation
+
+Added a mocked spec that covers both:
+
+1. Open Search dialog from the top bar search icon.
+2. Fill `Name contains` with a misspelling.
+3. Save the criteria as a new Saved Search.
+4. Run the search and assert "Did you mean" is shown.
+5. Click the suggestion and assert results update.
+
+### Code Touchpoints
+
+- Search results page (spellcheck UI):
+  - `ecm-frontend/src/pages/SearchResults.tsx`
+- Advanced Search dialog (Save Search flow):
+  - `ecm-frontend/src/components/search/SearchDialog.tsx`
+- Mocked E2E:
+  - `ecm-frontend/e2e/search-suggestions-save-search.mock.spec.ts`
+

--- a/docs/PHASE59_SEARCH_SUGGESTIONS_SAVED_SEARCH_UX_VERIFICATION_20260214.md
+++ b/docs/PHASE59_SEARCH_SUGGESTIONS_SAVED_SEARCH_UX_VERIFICATION_20260214.md
@@ -1,0 +1,35 @@
+# Phase 59 - Search: "Did You Mean" + Save Search Convenience (Verification)
+
+Date: 2026-02-14
+
+## What We Verify
+
+- A misspelled query produces a visible "Did you mean" suggestion.
+- Clicking a suggestion updates results (re-runs search with corrected query).
+- Saving a search from `Advanced Search` calls the Saved Search create endpoint and closes the save dialog.
+
+## Mocked E2E (No Backend Required)
+
+### Build + Serve
+
+```bash
+cd ecm-frontend
+npm run build
+python3 -m http.server 5500 --directory build
+```
+
+### Run Test
+
+```bash
+cd ecm-frontend
+ECM_UI_URL=http://localhost:5500 npx playwright test \
+  e2e/search-suggestions-save-search.mock.spec.ts \
+  --project=chromium --workers=1
+```
+
+## Expected Results
+
+- Playwright spec passes.
+- UI shows "Did you mean" for the misspelled query.
+- UI renders a result for the corrected query after clicking the suggestion.
+

--- a/docs/PHASE5_FULLSTACK_SMOKE_20260214.md
+++ b/docs/PHASE5_FULLSTACK_SMOKE_20260214.md
@@ -1,0 +1,61 @@
+# Phase 5 - Full-Stack Smoke (Optional, Docker Required)
+
+Date: 2026-02-14
+
+## Goal
+
+Provide a single CLI entrypoint to validate that key **Phase 5 admin pages** render correctly against the real stack:
+
+- Mail Automation (`/admin/mail`)
+- Preview Diagnostics (`/admin/preview-diagnostics`)
+
+This is intentionally small and fast compared to broader suites like `ui-smoke.spec.ts`.
+
+## Prerequisites
+
+- Backend API is healthy:
+  - `curl -fsS http://localhost:7700/actuator/health`
+- Keycloak is reachable:
+  - `curl -fsS http://localhost:8180/realms/ecm/.well-known/openid-configuration`
+- Frontend dev server is running (recommended):
+  - `http://localhost:3000`
+
+Note:
+- The static server on `:5500` does **not** proxy `/api` calls, so it is not suitable for full-stack UI tests unless you are behind a reverse-proxy that forwards `/api` to `:7700`.
+
+## What It Runs
+
+- Script: `scripts/phase5-fullstack-smoke.sh`
+- Playwright spec: `ecm-frontend/e2e/phase5-fullstack-admin-smoke.spec.ts`
+
+Auth behavior:
+- The E2E helper attempts to obtain an access token from Keycloak and seeds the UI session via `localStorage`, avoiding flaky UI login steps.
+
+## Command
+
+```bash
+bash scripts/phase5-fullstack-smoke.sh
+```
+
+## Environment Overrides
+
+- `ECM_UI_URL` (default `http://localhost:3000`)
+- `ECM_API_URL` (default `http://localhost:7700`)
+- `KEYCLOAK_URL` (default `http://localhost:8180`)
+- `KEYCLOAK_REALM` (default `ecm`)
+- `ECM_E2E_USERNAME` / `ECM_E2E_PASSWORD` (default `admin` / `admin`)
+- `PW_PROJECT` (default `chromium`)
+- `PW_WORKERS` (default `1`)
+
+Example:
+
+```bash
+ECM_UI_URL=http://localhost:3000 ECM_E2E_USERNAME=admin ECM_E2E_PASSWORD=admin \
+  bash scripts/phase5-fullstack-smoke.sh
+```
+
+## Expected Result
+
+- Playwright reports `1 passed`
+- Script ends with `phase5_fullstack_smoke: ok`
+

--- a/docs/PHASE5_PREVIEW_DIAGNOSTICS_REALCHAIN_VERIFICATION_20260214.md
+++ b/docs/PHASE5_PREVIEW_DIAGNOSTICS_REALCHAIN_VERIFICATION_20260214.md
@@ -1,0 +1,57 @@
+# Phase 5 - Preview Diagnostics Real-Chain Verification (Optional, Docker Required)
+
+Date: 2026-02-14
+
+## Goal
+
+Verify the end-to-end chain behind **Admin Preview Diagnostics**:
+
+1. Upload a deliberately corrupted PDF
+2. Preview pipeline attempts to generate a preview
+3. Document becomes `FAILED` or `UNSUPPORTED` with a failure reason
+4. The failure appears in:
+   - `GET /api/v1/preview/diagnostics/failures`
+   - UI page `/admin/preview-diagnostics`
+
+## Prerequisites
+
+- Full stack is running (API, DB, ES, preview pipeline workers, Keycloak)
+- Admin credentials available (defaults to `admin/admin`)
+
+## Command
+
+```bash
+bash scripts/phase5-preview-diagnostics-realchain.sh admin admin
+```
+
+## What It Does
+
+The script `scripts/phase5-preview-diagnostics-realchain.sh`:
+
+- Obtains an access token via `scripts/get-token.sh`
+- Uploads a corrupted PDF to the Root folder
+- Polls `/api/v1/preview/diagnostics/failures` until the uploaded filename appears
+- Prints a JSON summary (id/status/category/reason/lastUpdated)
+
+## Environment Overrides
+
+- `ECM_API_URL` (default `http://localhost:7700`)
+- `LIMIT` (default `200`)
+- `POLL_SECONDS` (default `120`)
+- `POLL_INTERVAL` (default `3`)
+- `EXPECT_REASON_SUBSTR` (optional)
+
+Example:
+
+```bash
+EXPECT_REASON_SUBSTR="Missing root object" bash scripts/phase5-preview-diagnostics-realchain.sh
+```
+
+## Expected Result
+
+- Script prints `FOUND: {...}` and ends with `phase5_preview_realchain: ok`
+
+If the document never appears:
+
+- Script exits non-zero with a hint to ensure preview workers are running and the failure status is recorded.
+

--- a/docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md
+++ b/docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md
@@ -30,6 +30,7 @@ The gate is intentionally **mocked-first** and runs against a static build serve
 - `ecm-frontend/e2e/search-suggestions-save-search.mock.spec.ts`
 - `ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts`
 - `ecm-frontend/e2e/mail-automation-diagnostics-export.mock.spec.ts`
+- `ecm-frontend/e2e/mail-automation-processed-management.mock.spec.ts`
 
 ## Behavior
 

--- a/docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md
+++ b/docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md
@@ -29,6 +29,7 @@ The gate is intentionally **mocked-first** and runs against a static build serve
 - `ecm-frontend/e2e/version-history-paging-major-only.mock.spec.ts`
 - `ecm-frontend/e2e/search-suggestions-save-search.mock.spec.ts`
 - `ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts`
+- `ecm-frontend/e2e/mail-automation-diagnostics-export.mock.spec.ts`
 
 ## Behavior
 

--- a/docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md
+++ b/docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md
@@ -12,6 +12,13 @@ Provide a single CLI entrypoint to validate the Phase 5 admin UX slices without 
 bash scripts/phase5-regression.sh
 ```
 
+## CI
+
+This gate is also executed in GitHub Actions:
+
+- Workflow: `.github/workflows/ci.yml`
+- Job: `frontend_e2e_phase5_mocked` (Phase 5 Mocked Regression Gate)
+
 ## What It Runs
 
 The gate is intentionally **mocked-first** and runs against a static build server (`:5500`):
@@ -49,4 +56,3 @@ ECM_UI_URL=http://localhost:5500 PW_WORKERS=2 bash scripts/phase5-regression.sh
 
 - This gate does not require Docker.
 - Integration suites (full-stack) remain separate, since they depend on Keycloak/DB/Elasticsearch.
-

--- a/docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md
+++ b/docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md
@@ -1,0 +1,52 @@
+# Phase 5 - Regression Gate Rollup (Mocked-First)
+
+Date: 2026-02-14
+
+## Goal
+
+Provide a single CLI entrypoint to validate the Phase 5 admin UX slices without requiring the full backend stack.
+
+## Command
+
+```bash
+bash scripts/phase5-regression.sh
+```
+
+## What It Runs
+
+The gate is intentionally **mocked-first** and runs against a static build server (`:5500`):
+
+- `ecm-frontend/e2e/admin-preview-diagnostics.mock.spec.ts`
+- `ecm-frontend/e2e/permissions-dialog-presets.mock.spec.ts`
+- `ecm-frontend/e2e/admin-audit-filter-export.mock.spec.ts`
+- `ecm-frontend/e2e/version-history-paging-major-only.mock.spec.ts`
+- `ecm-frontend/e2e/search-suggestions-save-search.mock.spec.ts`
+
+## Behavior
+
+The script:
+
+1. Builds the frontend (`npm run build`)
+2. Ensures a static server is reachable on `http://127.0.0.1:5500/` (starts one if needed)
+3. Runs Playwright with:
+   - `ECM_UI_URL` (default: `http://localhost:5500`)
+   - `--project=chromium`
+   - `--workers=1`
+
+## Environment Overrides
+
+- `ECM_UI_URL` (default `http://localhost:5500`)
+- `PW_PROJECT` (default `chromium`)
+- `PW_WORKERS` (default `1`)
+
+Example:
+
+```bash
+ECM_UI_URL=http://localhost:5500 PW_WORKERS=2 bash scripts/phase5-regression.sh
+```
+
+## Notes
+
+- This gate does not require Docker.
+- Integration suites (full-stack) remain separate, since they depend on Keycloak/DB/Elasticsearch.
+

--- a/docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md
+++ b/docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md
@@ -59,3 +59,6 @@ ECM_UI_URL=http://localhost:5500 PW_WORKERS=2 bash scripts/phase5-regression.sh
 
 - This gate does not require Docker.
 - Integration suites (full-stack) remain separate, since they depend on Keycloak/DB/Elasticsearch.
+- Optional full-stack smoke (when Docker/backends are healthy):
+  - Doc: `docs/PHASE5_FULLSTACK_SMOKE_20260214.md`
+  - Script: `scripts/phase5-fullstack-smoke.sh`

--- a/docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md
+++ b/docs/PHASE5_REGRESSION_GATE_ROLLUP_20260214.md
@@ -28,6 +28,7 @@ The gate is intentionally **mocked-first** and runs against a static build serve
 - `ecm-frontend/e2e/admin-audit-filter-export.mock.spec.ts`
 - `ecm-frontend/e2e/version-history-paging-major-only.mock.spec.ts`
 - `ecm-frontend/e2e/search-suggestions-save-search.mock.spec.ts`
+- `ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts`
 
 ## Behavior
 

--- a/ecm-core/entrypoint.sh
+++ b/ecm-core/entrypoint.sh
@@ -13,4 +13,9 @@ fi
 
 chown -R "$APP_USER":"$APP_USER" /var/ecm/temp /var/ecm/import /app/logs
 
-exec su -s /bin/sh "$APP_USER" -c "java -jar -Djava.security.egd=file:/dev/./urandom /app/app.jar"
+JAVA_BIN="${JAVA_BIN:-/opt/java/openjdk/bin/java}"
+if [ ! -x "$JAVA_BIN" ]; then
+  JAVA_BIN="$(command -v java)"
+fi
+
+exec su -s /bin/sh "$APP_USER" -c "$JAVA_BIN -jar -Djava.security.egd=file:/dev/./urandom /app/app.jar"

--- a/ecm-core/src/main/java/com/ecm/core/controller/DocumentController.java
+++ b/ecm-core/src/main/java/com/ecm/core/controller/DocumentController.java
@@ -72,12 +72,12 @@ public class DocumentController {
             // Create new document
             Document document = new Document();
             document.setName(file.getOriginalFilename());
-            document.setMimeType(file.getContentType());
             document.setFileSize(file.getSize());
             
             // Store content
             String contentId = contentService.storeContent(file);
             document.setContentId(contentId);
+            document.setMimeType(contentService.detectMimeType(contentId, file.getOriginalFilename()));
             
             UUID effectiveParentId = parentId != null ? parentId : folderId;
             Document created = (Document) nodeService.createNode(document, effectiveParentId);

--- a/ecm-core/src/main/java/com/ecm/core/controller/PreviewDiagnosticsController.java
+++ b/ecm-core/src/main/java/com/ecm/core/controller/PreviewDiagnosticsController.java
@@ -1,0 +1,90 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.entity.Document;
+import com.ecm.core.entity.PreviewStatus;
+import com.ecm.core.preview.PreviewFailureClassifier;
+import com.ecm.core.repository.DocumentRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/preview/diagnostics")
+@RequiredArgsConstructor
+@Tag(name = "Preview Diagnostics", description = "Admin-only diagnostics endpoints for preview generation")
+@PreAuthorize("hasRole('ADMIN')")
+public class PreviewDiagnosticsController {
+
+    private final DocumentRepository documentRepository;
+
+    @GetMapping("/failures")
+    @Operation(summary = "Recent preview failures", description = "List recent preview failures (FAILED/UNSUPPORTED) with derived categories.")
+    public ResponseEntity<List<PreviewFailureSampleDto>> getRecentFailures(
+        @RequestParam(defaultValue = "50") int limit
+    ) {
+        int safeLimit = Math.min(Math.max(limit, 1), 200);
+        Pageable pageable = PageRequest.of(0, safeLimit);
+
+        var statuses = List.of(PreviewStatus.FAILED, PreviewStatus.UNSUPPORTED);
+        var page = documentRepository.findRecentPreviewFailures(statuses, pageable);
+
+        List<PreviewFailureSampleDto> payload = page.getContent().stream()
+            .map(PreviewFailureSampleDto::from)
+            .toList();
+
+        return ResponseEntity.ok(payload);
+    }
+
+    public record PreviewFailureSampleDto(
+        UUID id,
+        String name,
+        String path,
+        String mimeType,
+        String previewStatus,
+        String previewFailureReason,
+        String previewFailureCategory,
+        LocalDateTime previewLastUpdated
+    ) {
+        static PreviewFailureSampleDto from(Document document) {
+            if (document == null) {
+                return null;
+            }
+            String status = document.getPreviewStatus() != null ? document.getPreviewStatus().name() : null;
+            String mimeType = normalizeMimeType(document.getMimeType());
+            String reason = document.getPreviewFailureReason();
+            String category = PreviewFailureClassifier.classify(status, mimeType, reason);
+            return new PreviewFailureSampleDto(
+                document.getId(),
+                document.getName(),
+                document.getPath(),
+                mimeType,
+                status,
+                reason,
+                category,
+                document.getPreviewLastUpdated()
+            );
+        }
+
+        private static String normalizeMimeType(String mimeType) {
+            if (mimeType == null || mimeType.isBlank()) {
+                return "";
+            }
+            String normalized = mimeType.split(";")[0].trim().toLowerCase(Locale.ROOT);
+            return normalized;
+        }
+    }
+}
+

--- a/ecm-core/src/main/java/com/ecm/core/pipeline/processor/ContentStorageProcessor.java
+++ b/ecm-core/src/main/java/com/ecm/core/pipeline/processor/ContentStorageProcessor.java
@@ -50,7 +50,7 @@ public class ContentStorageProcessor implements DocumentProcessor {
             context.setFileSize(fileSize);
 
             // Detect MIME type
-            String mimeType = contentService.detectMimeType(contentId);
+            String mimeType = contentService.detectMimeType(contentId, context.getOriginalFilename());
             context.setMimeType(mimeType);
 
             long processingTime = System.currentTimeMillis() - startTime;

--- a/ecm-core/src/main/java/com/ecm/core/repository/DocumentRepository.java
+++ b/ecm-core/src/main/java/com/ecm/core/repository/DocumentRepository.java
@@ -1,6 +1,7 @@
 package com.ecm.core.repository;
 
 import com.ecm.core.entity.Document;
+import com.ecm.core.entity.PreviewStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -132,5 +133,13 @@ public interface DocumentRepository extends JpaRepository<Document, UUID>, JpaSp
     Page<Document> findModifiedSinceInFolder(
         @Param("since") LocalDateTime since,
         @Param("folderId") UUID folderId,
+        Pageable pageable);
+
+    @Query("SELECT d FROM Document d " +
+           "WHERE d.deleted = false " +
+           "AND d.previewStatus IN :statuses " +
+           "ORDER BY d.previewLastUpdated DESC")
+    Page<Document> findRecentPreviewFailures(
+        @Param("statuses") List<PreviewStatus> statuses,
         Pageable pageable);
 }

--- a/ecm-core/src/main/java/com/ecm/core/service/VersionService.java
+++ b/ecm-core/src/main/java/com/ecm/core/service/VersionService.java
@@ -73,7 +73,7 @@ public class VersionService {
         
         // Store content
         String contentId = contentService.storeContent(content, filename);
-        String mimeType = contentService.detectMimeType(contentId);
+        String mimeType = contentService.detectMimeType(contentId, filename);
         long fileSize = contentService.getContentSize(contentId);
         
         // Extract content hash

--- a/ecm-core/src/test/java/com/ecm/core/controller/PreviewDiagnosticsControllerSecurityTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/PreviewDiagnosticsControllerSecurityTest.java
@@ -1,0 +1,125 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.entity.Document;
+import com.ecm.core.entity.PreviewStatus;
+import com.ecm.core.repository.DocumentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PreviewDiagnosticsController.class)
+@ContextConfiguration(classes = {
+    PreviewDiagnosticsController.class,
+    PreviewDiagnosticsControllerSecurityTest.TestSecurityConfig.class
+})
+class PreviewDiagnosticsControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DocumentRepository documentRepository;
+
+    @Configuration
+    @EnableWebSecurity
+    @EnableMethodSecurity(prePostEnabled = true)
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/api/**").authenticated()
+                    .anyRequest().permitAll()
+                )
+                .httpBasic(basic -> {});
+            return http.build();
+        }
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("Preview diagnostics requires admin role")
+    void diagnosticsRequiresAdmin() throws Exception {
+        mockMvc.perform(get("/api/v1/preview/diagnostics/failures"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Admin can access preview diagnostics and categories are derived")
+    void diagnosticsAllowsAdmin() throws Exception {
+        UUID docId = UUID.randomUUID();
+        LocalDateTime updated = LocalDateTime.of(2026, 2, 13, 12, 34, 56);
+
+        Document document = new Document();
+        document.setId(docId);
+        document.setName("broken.pdf");
+        document.setPath("/Root/Documents/broken.pdf");
+        document.setMimeType("application/pdf");
+        document.setPreviewStatus(PreviewStatus.FAILED);
+        document.setPreviewFailureReason("Error generating preview: Missing root object specification in trailer.");
+        document.setPreviewLastUpdated(updated);
+
+        Mockito.when(documentRepository.findRecentPreviewFailures(anyList(), any(Pageable.class)))
+            .thenReturn(new PageImpl<>(List.of(document), PageRequest.of(0, 50), 1));
+
+        mockMvc.perform(get("/api/v1/preview/diagnostics/failures?limit=50"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(1)))
+            .andExpect(jsonPath("$[0].id", is(docId.toString())))
+            .andExpect(jsonPath("$[0].name", is("broken.pdf")))
+            .andExpect(jsonPath("$[0].path", is("/Root/Documents/broken.pdf")))
+            .andExpect(jsonPath("$[0].mimeType", is("application/pdf")))
+            .andExpect(jsonPath("$[0].previewStatus", is("FAILED")))
+            .andExpect(jsonPath("$[0].previewFailureCategory", is("PERMANENT")))
+            .andExpect(jsonPath("$[0].previewFailureReason", is("Error generating preview: Missing root object specification in trailer.")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Limit is clamped to protect the API")
+    void limitIsClamped() throws Exception {
+        Mockito.when(documentRepository.findRecentPreviewFailures(anyList(), any(Pageable.class)))
+            .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 200), 0));
+
+        mockMvc.perform(get("/api/v1/preview/diagnostics/failures?limit=9999"))
+            .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        Mockito.verify(documentRepository).findRecentPreviewFailures(eq(List.of(PreviewStatus.FAILED, PreviewStatus.UNSUPPORTED)), captor.capture());
+        Pageable pageable = captor.getValue();
+        org.junit.jupiter.api.Assertions.assertEquals(200, pageable.getPageSize());
+        org.junit.jupiter.api.Assertions.assertEquals(0, pageable.getPageNumber());
+    }
+}
+

--- a/ecm-core/src/test/java/com/ecm/core/pipeline/processor/ContentStorageProcessorTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/pipeline/processor/ContentStorageProcessorTest.java
@@ -1,0 +1,57 @@
+package com.ecm.core.pipeline.processor;
+
+import com.ecm.core.pipeline.DocumentContext;
+import com.ecm.core.pipeline.ProcessingResult;
+import com.ecm.core.service.ContentService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ContentStorageProcessorTest {
+
+    @Mock
+    private ContentService contentService;
+
+    @InjectMocks
+    private ContentStorageProcessor processor;
+
+    @Test
+    @DisplayName("Detect MIME type using filename-aware detection for pipeline uploads")
+    void detectsMimeTypeWithFilename() throws Exception {
+        String filename = "test.pdf";
+        byte[] payload = "dummy".getBytes(StandardCharsets.UTF_8);
+        InputStream input = new ByteArrayInputStream(payload);
+
+        DocumentContext context = DocumentContext.builder()
+            .originalFilename(filename)
+            .inputStream(input)
+            .build();
+
+        when(contentService.storeContent(any(InputStream.class), eq(filename))).thenReturn("cid");
+        when(contentService.getContentSize("cid")).thenReturn((long) payload.length);
+        when(contentService.detectMimeType("cid", filename)).thenReturn("application/pdf");
+
+        ProcessingResult result = processor.process(context);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(context.getContentId()).isEqualTo("cid");
+        assertThat(context.getFileSize()).isEqualTo(payload.length);
+        assertThat(context.getMimeType()).isEqualTo("application/pdf");
+        verify(contentService).detectMimeType("cid", filename);
+    }
+}
+

--- a/ecm-core/src/test/java/com/ecm/core/preview/PreviewQueueServiceTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/preview/PreviewQueueServiceTest.java
@@ -68,10 +68,72 @@ class PreviewQueueServiceTest {
 
         assertEquals(PreviewStatus.UNSUPPORTED, status.previewStatus());
         assertEquals(false, status.queued());
+        assertEquals("Preview unsupported", status.message());
         verify(documentRepository, never()).save(any());
         verifyNoInteractions(searchIndexService);
 
         service.processQueue();
         verifyNoInteractions(previewService);
+    }
+
+    @Test
+    void blocksEnqueueForPermanentFailureWhenNotForced() {
+        DocumentRepository documentRepository = mock(DocumentRepository.class);
+        PreviewService previewService = mock(PreviewService.class);
+        SearchIndexService searchIndexService = mock(SearchIndexService.class);
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        PreviewQueueService service = new PreviewQueueService(documentRepository, previewService, searchIndexService, redisTemplate);
+
+        ReflectionTestUtils.setField(service, "queueEnabled", true);
+        ReflectionTestUtils.setField(service, "batchSize", 1);
+
+        UUID documentId = UUID.randomUUID();
+        Document document = new Document();
+        document.setId(documentId);
+        document.setMimeType("application/pdf");
+        document.setPreviewStatus(PreviewStatus.FAILED);
+        document.setPreviewFailureReason("Error generating preview: Missing root object specification in trailer.");
+
+        when(documentRepository.findById(documentId)).thenReturn(Optional.of(document));
+
+        PreviewQueueService.PreviewQueueStatus status = service.enqueue(documentId, false);
+
+        assertEquals(PreviewStatus.FAILED, status.previewStatus());
+        assertEquals(false, status.queued());
+        assertEquals("Preview failed permanently; use force=true to rebuild", status.message());
+        verify(documentRepository, never()).save(any());
+        verifyNoInteractions(searchIndexService);
+        verifyNoInteractions(previewService);
+    }
+
+    @Test
+    void allowsEnqueueForTemporaryFailureWhenNotForced() {
+        DocumentRepository documentRepository = mock(DocumentRepository.class);
+        PreviewService previewService = mock(PreviewService.class);
+        SearchIndexService searchIndexService = mock(SearchIndexService.class);
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        PreviewQueueService service = new PreviewQueueService(documentRepository, previewService, searchIndexService, redisTemplate);
+
+        ReflectionTestUtils.setField(service, "queueEnabled", true);
+        ReflectionTestUtils.setField(service, "batchSize", 1);
+
+        UUID documentId = UUID.randomUUID();
+        Document document = new Document();
+        document.setId(documentId);
+        document.setMimeType("application/pdf");
+        document.setPreviewStatus(PreviewStatus.FAILED);
+        document.setPreviewFailureReason("Timeout contacting preview service");
+
+        when(documentRepository.findById(documentId)).thenReturn(Optional.of(document));
+        when(documentRepository.save(any(Document.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PreviewQueueService.PreviewQueueStatus status = service.enqueue(documentId, false);
+
+        assertEquals(true, status.queued());
+        assertEquals("Preview queued", status.message());
+        assertEquals(PreviewStatus.PROCESSING, document.getPreviewStatus());
+        assertEquals(null, document.getPreviewFailureReason());
+        verify(documentRepository, atLeastOnce()).save(document);
+        verify(searchIndexService, atLeastOnce()).updateDocument(document);
     }
 }

--- a/ecm-frontend/e2e/admin-audit-filter-export.mock.spec.ts
+++ b/ecm-frontend/e2e/admin-audit-filter-export.mock.spec.ts
@@ -1,0 +1,207 @@
+import { expect, test } from '@playwright/test';
+import { seedBypassSessionE2E } from './helpers/login';
+
+test.use({ acceptDownloads: true });
+
+test('Admin audit filters persist in URL and export filename is stable (mocked API)', async ({ page }) => {
+  test.setTimeout(120_000);
+
+  await seedBypassSessionE2E(page, 'admin', 'e2e-token');
+
+  const nodeId = '11111111-1111-1111-1111-111111111111';
+  const fromValue = '2026-02-01T00:00';
+  const toValue = '2026-02-02T00:00';
+
+  const json = (body: unknown) => JSON.stringify(body);
+  const fulfillJson = (route: any, body: unknown) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: json(body),
+  });
+
+  await page.route('**/api/v1/**', async (route) => {
+    const requestUrl = new URL(route.request().url());
+    const pathname = requestUrl.pathname;
+
+    // File browser boot (app root)
+    if (pathname.endsWith('/folders/roots')) {
+      await fulfillJson(route, [
+        {
+          id: 'root-folder-id',
+          name: 'Root',
+          path: '/Root',
+          folderType: 'SYSTEM',
+          parentId: null,
+          inheritPermissions: true,
+          description: null,
+          createdBy: 'admin',
+          createdDate: new Date().toISOString(),
+          lastModifiedBy: 'admin',
+          lastModifiedDate: new Date().toISOString(),
+        },
+      ]);
+      return;
+    }
+    if (pathname.includes('/folders/') && pathname.endsWith('/contents')) {
+      await fulfillJson(route, { content: [], totalElements: 0, number: 0, size: 50 });
+      return;
+    }
+    if (pathname.endsWith('/favorites/batch/check')) {
+      await fulfillJson(route, { favoritedNodeIds: [] });
+      return;
+    }
+
+    // Admin dashboard bootstrap
+    if (pathname.endsWith('/analytics/dashboard')) {
+      await fulfillJson(route, {
+        summary: {
+          totalDocuments: 0,
+          totalFolders: 0,
+          totalSizeBytes: 0,
+          formattedTotalSize: '0 B',
+        },
+        storage: [],
+        activity: [],
+        topUsers: [{ username: 'admin', activityCount: 1 }],
+      });
+      return;
+    }
+    if (pathname.endsWith('/analytics/audit/recent')) {
+      await fulfillJson(route, []);
+      return;
+    }
+    if (pathname.endsWith('/system/license')) {
+      await fulfillJson(route, {
+        edition: 'Community',
+        maxUsers: 0,
+        maxStorageGb: 0,
+        expirationDate: null,
+        features: [],
+        valid: true,
+      });
+      return;
+    }
+    if (pathname.endsWith('/analytics/audit/retention')) {
+      await fulfillJson(route, { retentionDays: 90, expiredLogCount: 0, exportMaxRangeDays: 90 });
+      return;
+    }
+    if (pathname.endsWith('/analytics/audit/report')) {
+      await fulfillJson(route, { windowDays: 30, totalEvents: 1, countsByCategory: { NODE: 1 } });
+      return;
+    }
+    if (pathname.endsWith('/analytics/rules/summary')) {
+      await fulfillJson(route, null);
+      return;
+    }
+    if (pathname.endsWith('/analytics/rules/recent')) {
+      await fulfillJson(route, []);
+      return;
+    }
+    if (pathname.endsWith('/analytics/audit/presets')) {
+      await fulfillJson(route, []);
+      return;
+    }
+    if (pathname.endsWith('/analytics/audit/categories')) {
+      await fulfillJson(route, [{ category: 'NODE', enabled: true }]);
+      return;
+    }
+    if (pathname.endsWith('/analytics/audit/event-types')) {
+      await fulfillJson(route, [{ eventType: 'NODE_CREATED', count: 10 }]);
+      return;
+    }
+    if (pathname.endsWith('/search/saved')) {
+      await fulfillJson(route, []);
+      return;
+    }
+    if (pathname.endsWith('/integration/mail/fetch/summary')) {
+      await fulfillJson(route, { summary: null, fetchedAt: null });
+      return;
+    }
+
+    // Filtered audit search
+    if (pathname.endsWith('/analytics/audit/search')) {
+      expect(requestUrl.searchParams.get('username')).toBe('alice');
+      expect(requestUrl.searchParams.get('eventType')).toBe('NODE_CREATED');
+      expect(requestUrl.searchParams.get('category')).toBe('NODE');
+      expect(requestUrl.searchParams.get('nodeId')).toBe(nodeId);
+      expect(requestUrl.searchParams.get('from')).toBeTruthy();
+      expect(requestUrl.searchParams.get('to')).toBeTruthy();
+
+      await fulfillJson(route, {
+        content: [
+          {
+            id: 'audit-log-1',
+            eventType: 'NODE_CREATED',
+            nodeName: 'demo.txt',
+            username: 'alice',
+            eventTime: new Date().toISOString(),
+            details: 'Created demo.txt',
+          },
+        ],
+        totalElements: 1,
+        totalPages: 1,
+        number: 0,
+        size: 50,
+      });
+      return;
+    }
+
+    // Export endpoint returns a CSV payload.
+    if (pathname.endsWith('/analytics/audit/export')) {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv',
+          'X-Audit-Export-Count': '1',
+        },
+        body: 'id,eventType,nodeName,username,eventTime,details\n1,NODE_CREATED,demo.txt,alice,2026-02-01T00:00:00Z,Created demo.txt\n',
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: json({ message: `Not mocked: ${pathname}` }),
+    });
+  });
+
+  // When running against a static build server (no SPA rewrite), avoid deep links.
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('button', { name: 'Account menu' })).toBeVisible();
+  await page.getByRole('button', { name: 'Account menu' }).click();
+  await page.getByRole('menuitem', { name: 'Admin Dashboard' }).click();
+
+  await expect(page.getByRole('heading', { name: 'System Dashboard' })).toBeVisible({ timeout: 60_000 });
+
+  await page.getByLabel('User').fill('alice');
+  await page.getByLabel('Event Type').fill('NODE_CREATED');
+
+  await page.getByLabel('Category').click();
+  await page.getByRole('option', { name: 'Nodes' }).click();
+
+  await page.getByLabel('Node ID').fill(nodeId);
+  await page.getByRole('textbox', { name: 'From', exact: true }).fill(fromValue);
+  await page.getByRole('textbox', { name: 'To', exact: true }).fill(toValue);
+
+  await page.getByRole('button', { name: 'Filter Logs' }).click();
+
+  await expect(page).toHaveURL(/auditUser=alice/);
+  await expect(page).toHaveURL(new RegExp(`auditNodeId=${nodeId}`));
+  await expect(page).toHaveURL(/auditFrom=/);
+  await expect(page).toHaveURL(/auditTo=/);
+
+  await expect(page.getByText('alice - Node Created').first()).toBeVisible({ timeout: 60_000 });
+
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.getByRole('button', { name: 'Export CSV' }).click(),
+  ]);
+
+  const filename = download.suggestedFilename();
+  expect(filename).toContain('audit_logs_20260201_to_20260202');
+  expect(filename).toContain('user-alice');
+  expect(filename).toContain('event-NODE_CREATED');
+  expect(filename).toContain('cat-NODE');
+  expect(filename).toContain('node-11111111');
+});

--- a/ecm-frontend/e2e/admin-preview-diagnostics.mock.spec.ts
+++ b/ecm-frontend/e2e/admin-preview-diagnostics.mock.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from '@playwright/test';
+import { seedBypassSessionE2E } from './helpers/login';
+
+test('Preview diagnostics renders failures and gates retry actions (mocked API)', async ({ page }) => {
+  test.setTimeout(120_000);
+
+  const retryableId = '11111111-1111-1111-1111-111111111111';
+  const unsupportedId = '22222222-2222-2222-2222-222222222222';
+  const permanentId = '33333333-3333-3333-3333-333333333333';
+
+  const retryableName = 'e2e-preview-diagnostics-retryable.pdf';
+  const unsupportedName = 'e2e-preview-diagnostics-unsupported.bin';
+  const permanentName = 'e2e-preview-diagnostics-permanent.pdf';
+
+  await seedBypassSessionE2E(page, 'admin', 'e2e-token');
+
+  await page.route('**/api/v1/folders/roots', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'root-folder-id',
+          name: 'Root',
+          path: '/Root',
+          folderType: 'SYSTEM',
+          parentId: null,
+          inheritPermissions: true,
+          description: null,
+          createdBy: 'admin',
+          createdDate: new Date().toISOString(),
+          lastModifiedBy: 'admin',
+          lastModifiedDate: new Date().toISOString(),
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/folders/*/contents**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ content: [], totalElements: 0 }),
+    });
+  });
+
+  await page.route('**/api/v1/preview/diagnostics/failures**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: retryableId,
+          name: retryableName,
+          path: '/Root/Documents/e2e-preview-diagnostics/retryable.pdf',
+          mimeType: 'application/pdf',
+          previewStatus: 'FAILED',
+          previewFailureCategory: 'TEMPORARY',
+          previewFailureReason: 'Timeout contacting preview service',
+          previewLastUpdated: new Date().toISOString(),
+        },
+        {
+          id: unsupportedId,
+          name: unsupportedName,
+          path: '/Root/Documents/e2e-preview-diagnostics/unsupported.bin',
+          mimeType: 'application/octet-stream',
+          previewStatus: 'UNSUPPORTED',
+          previewFailureCategory: 'UNSUPPORTED',
+          previewFailureReason: 'Preview not supported for mime type application/octet-stream',
+          previewLastUpdated: new Date().toISOString(),
+        },
+        {
+          id: permanentId,
+          name: permanentName,
+          path: '/Root/Documents/e2e-preview-diagnostics/permanent.pdf',
+          mimeType: 'application/pdf',
+          previewStatus: 'FAILED',
+          previewFailureCategory: 'PERMANENT',
+          previewFailureReason: 'Error generating preview: Missing root object specification in trailer.',
+          previewLastUpdated: new Date().toISOString(),
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/documents/*/preview/queue**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'QUEUED' }),
+    });
+  });
+
+  // When running against a static build server (no SPA rewrite), avoid deep links.
+  // Navigate from the app root instead.
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('button', { name: 'Account menu' })).toBeVisible();
+  await page.getByRole('button', { name: 'Account menu' }).click();
+  await page.getByRole('menuitem', { name: 'Preview Diagnostics' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Preview Diagnostics' })).toBeVisible();
+
+  await expect(page.getByText('Total 3')).toBeVisible();
+  await expect(page.getByText('Retryable 1')).toBeVisible();
+  await expect(page.getByText('Permanent 1')).toBeVisible();
+  await expect(page.getByText('Unsupported 1')).toBeVisible();
+
+  const filter = page.getByPlaceholder('Filter by name, path, mime type...');
+  await filter.fill(retryableName);
+
+  const retryableRow = page.locator('tr', { hasText: retryableName });
+  await expect(retryableRow).toBeVisible();
+  // Tooltip wrapper includes a <span aria-label="Retry preview"> plus the real button; use role=button.
+  const retryButton = retryableRow.getByRole('button', { name: 'Retry preview' });
+  await expect(retryButton).toBeEnabled();
+  await retryButton.click();
+  await expect(page.getByText('Preview retry queued')).toBeVisible();
+
+  await filter.fill(unsupportedName);
+  const unsupportedRow = page.locator('tr', { hasText: unsupportedName });
+  await expect(unsupportedRow).toBeVisible();
+  await expect(unsupportedRow.getByRole('button', { name: 'Retry preview' })).toBeDisabled();
+  await expect(unsupportedRow.getByRole('button', { name: 'Force rebuild preview' })).toBeDisabled();
+});

--- a/ecm-frontend/e2e/admin-preview-diagnostics.spec.ts
+++ b/ecm-frontend/e2e/admin-preview-diagnostics.spec.ts
@@ -1,0 +1,110 @@
+import { APIRequestContext, expect, test } from '@playwright/test';
+import {
+  fetchAccessToken,
+  findChildFolderId,
+  getRootFolderId,
+  resolveApiUrl,
+  waitForApiReady,
+} from './helpers/api';
+import { gotoWithAuthE2E } from './helpers/login';
+
+const baseApiUrl = resolveApiUrl();
+const defaultUsername = process.env.ECM_E2E_USERNAME || 'admin';
+const defaultPassword = process.env.ECM_E2E_PASSWORD || 'admin';
+
+function randomLetters(length: number) {
+  let out = '';
+  while (out.length < length) {
+    out += Math.random().toString(36).replace(/[^a-z]+/g, '');
+  }
+  return out.slice(0, length);
+}
+
+async function createFolder(
+  request: APIRequestContext,
+  parentId: string,
+  name: string,
+  token: string
+) {
+  const res = await request.post(`${baseApiUrl}/api/v1/folders`, {
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    data: { name, parentId, folderType: 'GENERAL', inheritPermissions: true },
+  });
+  expect(res.ok()).toBeTruthy();
+  const payload = (await res.json()) as { id?: string };
+  if (!payload.id) {
+    throw new Error('Folder creation did not return id');
+  }
+  return payload.id;
+}
+
+async function uploadBinaryFile(
+  request: APIRequestContext,
+  folderId: string,
+  filename: string,
+  token: string
+) {
+  const uploadRes = await request.post(`${baseApiUrl}/api/v1/documents/upload?folderId=${folderId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    multipart: {
+      file: {
+        name: filename,
+        mimeType: 'application/octet-stream',
+        buffer: Buffer.from([1, 2, 3, 4, 5]),
+      },
+    },
+  });
+  expect(uploadRes.ok()).toBeTruthy();
+  const uploadJson = (await uploadRes.json()) as { documentId?: string; id?: string };
+  const documentId = uploadJson.documentId ?? uploadJson.id;
+  if (!documentId) {
+    throw new Error('Upload did not return document id');
+  }
+  return documentId;
+}
+
+test('Admin preview diagnostics lists recent failures and supports filtering', async ({ page, request }) => {
+  test.setTimeout(240_000);
+  await waitForApiReady(request, { apiUrl: baseApiUrl });
+
+  const token = await fetchAccessToken(request, defaultUsername, defaultPassword);
+  const rootId = await getRootFolderId(request, token, { apiUrl: baseApiUrl });
+  const documentsId = await findChildFolderId(request, rootId, 'Documents', token, { apiUrl: baseApiUrl });
+
+  const folderName = `e2e-preview-diagnostics-${Date.now()}`;
+  const folderId = await createFolder(request, documentsId, folderName, token);
+  const filename = `e2e-preview-diagnostics-${Date.now()}-${randomLetters(8)}.bin`;
+  const documentId = await uploadBinaryFile(request, folderId, filename, token);
+
+  const previewRes = await request.get(`${baseApiUrl}/api/v1/documents/${documentId}/preview`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  expect(previewRes.ok()).toBeTruthy();
+  const previewJson = (await previewRes.json()) as { supported?: boolean; status?: string; failureCategory?: string };
+  expect(previewJson.supported).toBe(false);
+  expect(previewJson.status).toBe('UNSUPPORTED');
+  expect(previewJson.failureCategory).toBe('UNSUPPORTED');
+
+  await expect.poll(async () => {
+    const diagRes = await request.get(`${baseApiUrl}/api/v1/preview/diagnostics/failures?limit=200`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!diagRes.ok()) {
+      return false;
+    }
+    const payload = (await diagRes.json()) as Array<{ id?: string; name?: string }>;
+    return payload.some((item) => item.id === documentId || item.name === filename);
+  }, { timeout: 60_000, intervals: [500, 1000, 2000] }).toBeTruthy();
+
+  await gotoWithAuthE2E(page, '/admin/preview-diagnostics', defaultUsername, defaultPassword, { token });
+  await expect(page.getByRole('heading', { name: 'Preview Diagnostics' })).toBeVisible({ timeout: 60_000 });
+
+  const filter = page.getByPlaceholder('Filter by name, path, mime type...');
+  await filter.fill(filename);
+  await expect(page.getByText(filename)).toBeVisible({ timeout: 60_000 });
+
+  await request.delete(`${baseApiUrl}/api/v1/nodes/${folderId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  }).catch(() => null);
+});
+

--- a/ecm-frontend/e2e/mail-automation-diagnostics-export.mock.spec.ts
+++ b/ecm-frontend/e2e/mail-automation-diagnostics-export.mock.spec.ts
@@ -1,0 +1,357 @@
+import { expect, test } from '@playwright/test';
+import { seedBypassSessionE2E } from './helpers/login';
+
+test('Mail automation: List folders, run diagnostics, export CSVs, and copy diagnostics link (mocked API)', async ({ page }) => {
+  test.setTimeout(120_000);
+
+  await page.addInitScript(() => {
+    // Avoid relying on system clipboard permissions in CI/local runs.
+    (window as any).__copiedText = null;
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: async (text: string) => {
+          (window as any).__copiedText = text;
+        },
+      },
+      configurable: true,
+    });
+
+    // Capture anchor-triggered blob downloads (Mail Automation exports use URL.createObjectURL + <a download>).
+    (window as any).__downloads = [];
+    const origClick = HTMLElement.prototype.click;
+    HTMLElement.prototype.click = function clickPatched(this: HTMLElement) {
+      try {
+        if (this instanceof HTMLAnchorElement) {
+          const href = this.href || '';
+          const download = this.download || '';
+          if (download) {
+            (window as any).__downloads.push({ href, download });
+            return;
+          }
+        }
+      } catch {
+        // Ignore cross-realm / prototype issues in unusual environments.
+      }
+      return origClick.call(this);
+    };
+  });
+
+  await seedBypassSessionE2E(page, 'admin', 'e2e-token');
+
+  await page.route('**/api/v1/folders/roots', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'root-folder-id',
+          name: 'Root',
+          path: '/Root',
+          folderType: 'SYSTEM',
+          parentId: null,
+          inheritPermissions: true,
+          description: null,
+          createdBy: 'admin',
+          createdDate: new Date().toISOString(),
+          lastModifiedBy: 'admin',
+          lastModifiedDate: new Date().toISOString(),
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/folders/*/contents**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ content: [], totalElements: 0 }),
+    });
+  });
+
+  await page.route('**/api/v1/tags**', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+  });
+
+  const accountId = 'gmail-imap';
+  const ruleId = 'gmail-attachments';
+
+  await page.route('**/api/v1/integration/mail/accounts**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: accountId,
+          name: 'gmail-imap',
+          host: 'imap.gmail.com',
+          port: 993,
+          username: 'admin@example.com',
+          security: 'OAUTH2',
+          enabled: true,
+          pollIntervalMinutes: 10,
+          oauthProvider: 'GOOGLE',
+          oauthConnected: true,
+          passwordConfigured: false,
+          oauthEnvConfigured: true,
+          oauthMissingEnvKeys: [],
+          lastFetchAt: null,
+          lastFetchStatus: null,
+          lastFetchError: null,
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/rules**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: ruleId,
+          name: 'gmail-attachments',
+          accountId,
+          priority: 0,
+          enabled: true,
+          folder: 'INBOX',
+          actionType: 'ATTACHMENTS_ONLY',
+          mailAction: 'MARK_READ',
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/fetch/summary**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ summary: null, fetchedAt: null }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/processed/retention**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ retentionDays: 90, enabled: true, expiredCount: 0 }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/report/schedule**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        enabled: true,
+        cron: '0 */10 * * * *',
+        folderId: null,
+        days: 30,
+        accountId,
+        ruleId,
+        lastExport: null,
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/report**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        accountId,
+        ruleId,
+        startDate: '2026-01-14',
+        endDate: '2026-02-12',
+        days: 30,
+        totals: { processed: 18, errors: 0, total: 18 },
+        accounts: [
+          {
+            accountId,
+            accountName: 'gmail-imap',
+            processed: 18,
+            errors: 0,
+            total: 18,
+            lastProcessedAt: '2026-01-28T00:31:54Z',
+            lastErrorAt: null,
+          },
+        ],
+        rules: [
+          {
+            ruleId,
+            ruleName: 'gmail-attachments',
+            accountId,
+            accountName: 'gmail-imap',
+            processed: 18,
+            errors: 0,
+            total: 18,
+            lastProcessedAt: '2026-01-28T00:31:54Z',
+            lastErrorAt: null,
+          },
+        ],
+        trend: [],
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/runtime-metrics**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        windowMinutes: 60,
+        attempts: 1,
+        successes: 1,
+        errors: 0,
+        errorRate: 0,
+        avgDurationMs: 4100,
+        lastSuccessAt: '2026-01-28T00:31:54Z',
+        lastErrorAt: null,
+        status: 'HEALTHY',
+        topErrors: [],
+        trend: null,
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/diagnostics**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        limit: 25,
+        recentProcessed: [],
+        recentDocuments: [],
+      }),
+    });
+  });
+
+  await page.route(`**/api/v1/integration/mail/accounts/${accountId}/folders`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(['INBOX', 'ECM-TEST', '[Gmail]/Important']),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/fetch/debug**', async (route) => {
+    if (route.request().method().toUpperCase() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        summary: {
+          accounts: 1,
+          attemptedAccounts: 1,
+          skippedAccounts: 0,
+          accountErrors: 0,
+          foundMessages: 3,
+          matchedMessages: 2,
+          processedMessages: 1,
+          skippedMessages: 1,
+          errorMessages: 0,
+          durationMs: 4100,
+          runId: 'debug-run-abcdef12',
+        },
+        maxMessagesPerFolder: 200,
+        skipReasons: { already_processed: 1 },
+        accounts: [
+          {
+            accountId,
+            accountName: 'gmail-imap',
+            attempted: true,
+            rules: 1,
+            folders: 1,
+            foundMessages: 3,
+            scannedMessages: 3,
+            matchedMessages: 2,
+            processableMessages: 1,
+            skippedMessages: 1,
+            errorMessages: 0,
+            skipReasons: { already_processed: 1 },
+            ruleMatches: { [ruleId]: 2 },
+            folderResults: [
+              {
+                folder: 'INBOX',
+                rules: 1,
+                foundMessages: 3,
+                scannedMessages: 3,
+                matchedMessages: 2,
+                processableMessages: 1,
+                skippedMessages: 1,
+                errorMessages: 0,
+                skipReasons: { already_processed: 1 },
+              },
+            ],
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/report/export**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/csv',
+      body: [
+        'account,rule,processed,errors,total',
+        'gmail-imap,gmail-attachments,18,0,18',
+        '',
+      ].join('\n'),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/diagnostics/export**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/csv',
+      body: ['processedAt,status,account,rule,uid,subject,error', ''].join('\n'),
+    });
+  });
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('button', { name: 'Account menu' })).toBeVisible();
+  await page.getByRole('button', { name: 'Account menu' }).click();
+  await page.getByRole('menuitem', { name: 'Mail Automation' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Mail Automation' })).toBeVisible();
+
+  const cardByHeading = (name: string) =>
+    page.getByRole('heading', { name }).locator('xpath=ancestor::div[contains(@class,"MuiCard-root")][1]');
+
+  const reportingCard = cardByHeading('Mail Reporting');
+  const reportExportButton = reportingCard.getByRole('button', { name: 'Export CSV' });
+  await expect(reportExportButton).toBeEnabled();
+  await reportExportButton.click();
+
+  const downloadsAfterReport = await page.evaluate(() => (window as any).__downloads || []);
+  expect(downloadsAfterReport.some((item: any) => typeof item.download === 'string' && /^mail-report-/.test(item.download))).toBeTruthy();
+
+  const diagnosticsCard = cardByHeading('Fetch Diagnostics (Dry Run)');
+  const listFoldersButton = diagnosticsCard.getByRole('button', { name: 'List Folders' });
+  await listFoldersButton.click();
+  await expect(page.getByText('Found 3 folders')).toBeVisible();
+  await expect(page.getByText('Available folders (3)')).toBeVisible();
+  await expect(page.getByText('ECM-TEST')).toBeVisible();
+
+  await diagnosticsCard.getByRole('button', { name: 'Run Diagnostics' }).click();
+  await expect(page.getByText('Diagnostics complete: matched 2, processable 1 in 4.1s')).toBeVisible();
+  await expect(diagnosticsCard.getByText('Attempted: 1').first()).toBeVisible();
+  await expect(diagnosticsCard.getByText('Matched: 2').first()).toBeVisible();
+  await expect(diagnosticsCard.getByText('Processable: 1').first()).toBeVisible();
+
+  const recentActivityCard = cardByHeading('Recent Mail Activity');
+  await recentActivityCard.getByRole('button', { name: 'Copy link' }).click();
+  await expect(page.getByText('Diagnostics link copied')).toBeVisible();
+  const copied = await page.evaluate(() => (window as any).__copiedText);
+  expect(String(copied)).toContain('#diagnostics');
+
+  const diagnosticsExportButton = recentActivityCard.getByRole('button', { name: 'Export CSV' });
+  await expect(diagnosticsExportButton).toBeEnabled();
+  await diagnosticsExportButton.click();
+
+  const downloadsAfterDiagnostics = await page.evaluate(() => (window as any).__downloads || []);
+  expect(downloadsAfterDiagnostics.some((item: any) => typeof item.download === 'string' && /^mail-diagnostics-/.test(item.download))).toBeTruthy();
+});

--- a/ecm-frontend/e2e/mail-automation-diagnostics-export.mock.spec.ts
+++ b/ecm-frontend/e2e/mail-automation-diagnostics-export.mock.spec.ts
@@ -324,8 +324,11 @@ test('Mail automation: List folders, run diagnostics, export CSVs, and copy diag
   const reportingCard = cardByHeading('Mail Reporting');
   const reportExportButton = reportingCard.getByRole('button', { name: 'Export CSV' });
   await expect(reportExportButton).toBeEnabled();
+  const downloadsBeforeReport = await page.evaluate(() => ((window as any).__downloads || []).length);
   await reportExportButton.click();
 
+  // Export fetch + blob conversion is async; wait for the programmatic anchor click to be captured.
+  await page.waitForFunction((before) => ((window as any).__downloads || []).length > before, downloadsBeforeReport);
   const downloadsAfterReport = await page.evaluate(() => (window as any).__downloads || []);
   expect(downloadsAfterReport.some((item: any) => typeof item.download === 'string' && /^mail-report-/.test(item.download))).toBeTruthy();
 
@@ -350,8 +353,13 @@ test('Mail automation: List folders, run diagnostics, export CSVs, and copy diag
 
   const diagnosticsExportButton = recentActivityCard.getByRole('button', { name: 'Export CSV' });
   await expect(diagnosticsExportButton).toBeEnabled();
+  const downloadsBeforeDiagnostics = await page.evaluate(() => ((window as any).__downloads || []).length);
   await diagnosticsExportButton.click();
 
+  await page.waitForFunction(
+    (before) => ((window as any).__downloads || []).length > before,
+    downloadsBeforeDiagnostics
+  );
   const downloadsAfterDiagnostics = await page.evaluate(() => (window as any).__downloads || []);
   expect(downloadsAfterDiagnostics.some((item: any) => typeof item.download === 'string' && /^mail-diagnostics-/.test(item.download))).toBeTruthy();
 });

--- a/ecm-frontend/e2e/mail-automation-processed-management.mock.spec.ts
+++ b/ecm-frontend/e2e/mail-automation-processed-management.mock.spec.ts
@@ -1,0 +1,364 @@
+import { expect, test } from '@playwright/test';
+import { seedBypassSessionE2E } from './helpers/login';
+
+test('Mail automation: processed retention, cleanup, bulk delete, replay, and view ingested docs (mocked API)', async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+
+  // Accept confirm() prompts used by destructive actions (cleanup/delete).
+  page.on('dialog', async (dialog) => {
+    await dialog.accept();
+  });
+
+  await seedBypassSessionE2E(page, 'admin', 'e2e-token');
+
+  await page.route('**/api/v1/folders/roots', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'root-folder-id',
+          name: 'Root',
+          path: '/Root',
+          folderType: 'SYSTEM',
+          parentId: null,
+          inheritPermissions: true,
+          description: null,
+          createdBy: 'admin',
+          createdDate: new Date().toISOString(),
+          lastModifiedBy: 'admin',
+          lastModifiedDate: new Date().toISOString(),
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/folders/*/contents**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ content: [], totalElements: 0 }),
+    });
+  });
+
+  await page.route('**/api/v1/tags**', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+  });
+
+  const accountId = 'gmail-imap';
+  const ruleId = 'gmail-attachments';
+
+  await page.route('**/api/v1/integration/mail/accounts**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: accountId,
+          name: 'gmail-imap',
+          host: 'imap.gmail.com',
+          port: 993,
+          username: 'admin@example.com',
+          security: 'OAUTH2',
+          enabled: true,
+          pollIntervalMinutes: 10,
+          oauthProvider: 'GOOGLE',
+          oauthConnected: true,
+          passwordConfigured: false,
+          oauthEnvConfigured: true,
+          oauthMissingEnvKeys: [],
+          lastFetchAt: null,
+          lastFetchStatus: null,
+          lastFetchError: null,
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/rules**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: ruleId,
+          name: 'gmail-attachments',
+          accountId,
+          priority: 0,
+          enabled: true,
+          folder: 'INBOX',
+          actionType: 'ATTACHMENTS_ONLY',
+          mailAction: 'MARK_READ',
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/fetch/summary**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ summary: null, fetchedAt: null }),
+    });
+  });
+
+  // Stateful retention + diagnostics so post-actions can observe updates.
+  const retention = { retentionDays: 90, enabled: true, expiredCount: 2 };
+
+  const processedOk = {
+    id: 'processed-ok-1',
+    processedAt: '2026-02-12T00:31:54Z',
+    status: 'PROCESSED',
+    accountId,
+    accountName: 'gmail-imap',
+    ruleId,
+    ruleName: 'gmail-attachments',
+    folder: 'INBOX',
+    uid: '12351',
+    subject: 'Invoice 2026-02',
+    errorMessage: null,
+  };
+
+  const processedErr = {
+    id: 'processed-err-1',
+    processedAt: '2026-02-12T01:02:03Z',
+    status: 'ERROR',
+    accountId,
+    accountName: 'gmail-imap',
+    ruleId,
+    ruleName: 'gmail-attachments',
+    folder: 'INBOX',
+    uid: '12352',
+    subject: 'Broken attachment',
+    errorMessage: 'Failed to parse attachment metadata',
+  };
+
+  const diagnosticsState: {
+    limit: number;
+    recentProcessed: any[];
+    recentDocuments: any[];
+  } = {
+    limit: 25,
+    recentProcessed: [processedOk, processedErr],
+    recentDocuments: [
+      {
+        documentId: 'doc-1',
+        name: 'invoice.pdf',
+        path: '/Root/Documents/Invoices/invoice.pdf',
+        createdDate: '2026-02-12T00:31:58Z',
+        createdBy: 'admin',
+        mimeType: 'application/pdf',
+        fileSize: 12950,
+        accountId,
+        accountName: 'gmail-imap',
+        ruleId,
+        ruleName: 'gmail-attachments',
+        folder: 'INBOX',
+        uid: '12351',
+      },
+    ],
+  };
+
+  const processedDocsById: Record<string, any[]> = {
+    [processedOk.id]: [
+      {
+        documentId: 'doc-1',
+        name: 'invoice.pdf',
+        path: '/Root/Documents/Invoices/invoice.pdf',
+        createdDate: '2026-02-12T00:31:58Z',
+        createdBy: 'admin',
+        mimeType: 'application/pdf',
+        fileSize: 12950,
+        accountId,
+        accountName: 'gmail-imap',
+        ruleId,
+        ruleName: 'gmail-attachments',
+        folder: 'INBOX',
+        uid: '12351',
+      },
+    ],
+    [processedErr.id]: [],
+  };
+
+  await page.route('**/api/v1/integration/mail/processed/retention**', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(retention) });
+  });
+
+  await page.route('**/api/v1/integration/mail/report/schedule**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        enabled: true,
+        cron: '0 */10 * * * *',
+        folderId: null,
+        days: 30,
+        accountId,
+        ruleId,
+        lastExport: null,
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/report**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        accountId,
+        ruleId,
+        startDate: '2026-01-14',
+        endDate: '2026-02-12',
+        days: 30,
+        totals: { processed: 18, errors: 1, total: 19 },
+        accounts: [],
+        rules: [],
+        trend: [],
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/runtime-metrics**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        windowMinutes: 60,
+        attempts: 1,
+        successes: 1,
+        errors: 0,
+        errorRate: 0,
+        avgDurationMs: 4100,
+        lastSuccessAt: '2026-02-12T00:31:54Z',
+        lastErrorAt: null,
+        status: 'HEALTHY',
+        topErrors: [],
+        trend: null,
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/diagnostics**', async (route) => {
+    // Avoid catching export endpoint (`/diagnostics/export`) here; that is covered in a dedicated spec.
+    if (route.request().url().includes('/api/v1/integration/mail/diagnostics/export')) {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(diagnosticsState),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/processed/bulk-delete', async (route) => {
+    if (route.request().method().toUpperCase() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+    const body = route.request().postDataJSON() as { ids?: string[] };
+    const ids = Array.isArray(body?.ids) ? body.ids : [];
+    diagnosticsState.recentProcessed = diagnosticsState.recentProcessed.filter((item) => !ids.includes(item.id));
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ deleted: ids.length }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/processed/cleanup', async (route) => {
+    if (route.request().method().toUpperCase() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+    const deleted = retention.expiredCount;
+    retention.expiredCount = 0;
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ deleted }) });
+  });
+
+  await page.route('**/api/v1/integration/mail/processed/*/replay', async (route) => {
+    if (route.request().method().toUpperCase() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+    const url = route.request().url();
+    const id = url.split('/processed/')[1]?.split('/replay')[0] || '';
+    diagnosticsState.recentProcessed = diagnosticsState.recentProcessed.map((item) =>
+      item.id === id
+        ? {
+            ...item,
+            status: 'PROCESSED',
+            errorMessage: null,
+          }
+        : item
+    );
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        processedMailId: id,
+        attempted: true,
+        processed: true,
+        message: 'ok',
+        replayStatus: 'PROCESSED',
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/processed/*/documents**', async (route) => {
+    const url = route.request().url();
+    const id = url.split('/processed/')[1]?.split('/documents')[0] || '';
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(processedDocsById[id] || []),
+    });
+  });
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('button', { name: 'Account menu' })).toBeVisible();
+  await page.getByRole('button', { name: 'Account menu' }).click();
+  await page.getByRole('menuitem', { name: 'Mail Automation' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Mail Automation' })).toBeVisible();
+  await expect(page.getByText('Retention 90d')).toBeVisible();
+  await expect(page.getByText('Expired 2')).toBeVisible();
+
+  const processedTable = page.locator('table').filter({ hasText: 'Linked Doc' }).first();
+  await expect(processedTable.locator('tbody tr')).toHaveCount(2);
+
+  const deleteSelected = page.getByRole('button', { name: 'Delete Selected', exact: true });
+  await expect(deleteSelected).toBeDisabled();
+
+  // Replay the failed item and verify the action is gated away after refresh.
+  await processedTable
+    .locator('tbody tr')
+    .filter({ hasText: 'ERROR' })
+    .getByRole('button', { name: 'Replay' })
+    .click();
+  await expect(page.getByText('Replay processed successfully')).toBeVisible();
+  await expect(processedTable.getByRole('button', { name: 'Replay' })).toHaveCount(0);
+
+  // View ingested docs for the processed item.
+  await processedTable.getByLabel('view ingested documents').first().click();
+  const docsDialog = page.getByTestId('processed-mail-docs-dialog');
+  await expect(docsDialog).toBeVisible();
+  await expect(docsDialog.getByRole('cell', { name: 'invoice.pdf', exact: true })).toBeVisible();
+  await docsDialog.getByRole('button', { name: 'Close' }).click();
+  await expect(docsDialog).toBeHidden();
+
+  // Clean up expired processed records and verify retention updates.
+  await page.getByRole('button', { name: 'Clean up expired' }).click();
+  await expect(page.getByText('Deleted 2 expired processed record(s)')).toBeVisible();
+  await expect(page.getByText('Expired 0')).toBeVisible();
+
+  // Select a row and bulk delete.
+  await processedTable.locator('tbody tr').nth(0).getByRole('checkbox').check();
+  await expect(deleteSelected).toBeEnabled();
+  await deleteSelected.click();
+  await expect(page.getByText('Deleted 1 processed record(s)')).toBeVisible();
+  await expect(processedTable.locator('tbody tr')).toHaveCount(1);
+  await expect(deleteSelected).toBeDisabled();
+});

--- a/ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts
+++ b/ecm-frontend/e2e/mail-automation-trigger-fetch.mock.spec.ts
@@ -1,0 +1,256 @@
+import { expect, test } from '@playwright/test';
+import { seedBypassSessionE2E } from './helpers/login';
+
+test('Mail automation: Trigger Fetch updates last fetch summary and copies run id (mocked API)', async ({ page }) => {
+  test.setTimeout(120_000);
+
+  await page.addInitScript(() => {
+    // Avoid relying on system clipboard permissions in CI/local runs.
+    (window as any).__copiedText = null;
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: async (text: string) => {
+          (window as any).__copiedText = text;
+        },
+      },
+      configurable: true,
+    });
+  });
+
+  await seedBypassSessionE2E(page, 'admin', 'e2e-token');
+
+  await page.route('**/api/v1/folders/roots', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'root-folder-id',
+          name: 'Root',
+          path: '/Root',
+          folderType: 'SYSTEM',
+          parentId: null,
+          inheritPermissions: true,
+          description: null,
+          createdBy: 'admin',
+          createdDate: new Date().toISOString(),
+          lastModifiedBy: 'admin',
+          lastModifiedDate: new Date().toISOString(),
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/folders/*/contents**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ content: [], totalElements: 0 }),
+    });
+  });
+
+  await page.route('**/api/v1/tags**', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+  });
+
+  const accountId = 'gmail-imap';
+  const ruleId = 'gmail-attachments';
+  const runId = '12345678abcdef';
+
+  await page.route('**/api/v1/integration/mail/accounts**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: accountId,
+          name: 'gmail-imap',
+          host: 'imap.gmail.com',
+          port: 993,
+          username: 'admin@example.com',
+          security: 'OAUTH2',
+          enabled: true,
+          pollIntervalMinutes: 10,
+          oauthProvider: 'GOOGLE',
+          oauthConnected: true,
+          passwordConfigured: false,
+          oauthEnvConfigured: true,
+          oauthMissingEnvKeys: [],
+          lastFetchAt: null,
+          lastFetchStatus: null,
+          lastFetchError: null,
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/rules**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: ruleId,
+          name: 'gmail-attachments',
+          accountId,
+          priority: 0,
+          enabled: true,
+          folder: 'INBOX',
+          actionType: 'ATTACHMENTS_ONLY',
+          mailAction: 'MARK_READ',
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/fetch/summary**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ summary: null, fetchedAt: null }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/processed/retention**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ retentionDays: 90, enabled: true, expiredCount: 0 }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/report/schedule**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        enabled: true,
+        cron: '0 */10 * * * *',
+        folderId: null,
+        days: 30,
+        accountId,
+        ruleId,
+        lastExport: null,
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/report**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        accountId,
+        ruleId,
+        startDate: '2026-01-14',
+        endDate: '2026-02-12',
+        days: 30,
+        totals: { processed: 18, errors: 0, total: 18 },
+        accounts: [
+          {
+            accountId,
+            accountName: 'gmail-imap',
+            processed: 18,
+            errors: 0,
+            total: 18,
+            lastProcessedAt: '2026-01-28T00:31:54Z',
+            lastErrorAt: null,
+          },
+        ],
+        rules: [
+          {
+            ruleId,
+            ruleName: 'gmail-attachments',
+            accountId,
+            accountName: 'gmail-imap',
+            processed: 18,
+            errors: 0,
+            total: 18,
+            lastProcessedAt: '2026-01-28T00:31:54Z',
+            lastErrorAt: null,
+          },
+        ],
+        trend: [],
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/runtime-metrics**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        windowMinutes: 60,
+        attempts: 1,
+        successes: 1,
+        errors: 0,
+        errorRate: 0,
+        avgDurationMs: 4100,
+        lastSuccessAt: '2026-01-28T00:31:54Z',
+        lastErrorAt: null,
+        status: 'HEALTHY',
+        topErrors: [],
+        trend: null,
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/diagnostics**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        limit: 25,
+        recentProcessed: [],
+        recentDocuments: [],
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/integration/mail/fetch', async (route) => {
+    if (route.request().method().toUpperCase() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        accounts: 1,
+        attemptedAccounts: 1,
+        skippedAccounts: 0,
+        accountErrors: 0,
+        foundMessages: 1,
+        matchedMessages: 1,
+        processedMessages: 1,
+        skippedMessages: 0,
+        errorMessages: 0,
+        durationMs: 4100,
+        runId,
+      }),
+    });
+  });
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('button', { name: 'Account menu' })).toBeVisible();
+  await page.getByRole('button', { name: 'Account menu' }).click();
+  await page.getByRole('menuitem', { name: 'Mail Automation' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Mail Automation' })).toBeVisible();
+  await expect(page.getByText('No fetch summary yet. Use Trigger Fetch to capture the latest run.')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Trigger Fetch' }).click();
+  await expect(page.getByText('Processed 1 of 1 matched')).toBeVisible();
+
+  await expect(page.getByText('Accounts 1')).toBeVisible();
+  await expect(page.getByText('Attempted 1')).toBeVisible();
+  await expect(page.getByText('Found 1')).toBeVisible();
+  await expect(page.getByText('Matched 1')).toBeVisible();
+  await expect(page.getByText('Processed 1', { exact: true })).toBeVisible();
+  await expect(page.getByText('Duration 4.1s')).toBeVisible();
+
+  await page.getByText('Run 12345678').click();
+  await expect(page.getByText('Run id copied')).toBeVisible();
+  const copied = await page.evaluate(() => (window as any).__copiedText);
+  expect(copied).toBe(runId);
+});

--- a/ecm-frontend/e2e/permissions-dialog-presets.mock.spec.ts
+++ b/ecm-frontend/e2e/permissions-dialog-presets.mock.spec.ts
@@ -1,0 +1,278 @@
+import { expect, test } from '@playwright/test';
+import { seedBypassSessionE2E } from './helpers/login';
+
+test('Permissions dialog shows effective permission presets (mocked API)', async ({ page }) => {
+  test.setTimeout(120_000);
+
+  const nodeId = 'e2e-permissions-node-id';
+  const nodeName = 'e2e-permissions-preset-target';
+
+  await seedBypassSessionE2E(page, 'admin', 'e2e-token');
+
+  await page.route('**/api/v1/folders/roots', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'root-folder-id',
+          name: 'Root',
+          path: '/Root',
+          folderType: 'SYSTEM',
+          parentId: null,
+          inheritPermissions: true,
+          description: null,
+          createdBy: 'admin',
+          createdDate: new Date().toISOString(),
+          lastModifiedBy: 'admin',
+          lastModifiedDate: new Date().toISOString(),
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/folders/*/contents**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        content: [
+          {
+            id: nodeId,
+            name: nodeName,
+            path: `/Root/Documents/${nodeName}`,
+            nodeType: 'FOLDER',
+            parentId: 'root-folder-id',
+            size: 0,
+            createdBy: 'admin',
+            createdDate: new Date().toISOString(),
+            lastModifiedBy: 'admin',
+            lastModifiedDate: new Date().toISOString(),
+            contentType: null,
+          },
+        ],
+        totalElements: 1,
+        number: 0,
+        size: 50,
+      }),
+    });
+  });
+
+  await page.route(`**/api/v1/nodes/${nodeId}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: nodeId,
+        name: nodeName,
+        path: `/Root/Documents/${nodeName}`,
+        nodeType: 'FOLDER',
+        parentId: 'root-folder-id',
+        size: 0,
+        contentType: null,
+        currentVersionLabel: null,
+        correspondentId: null,
+        correspondentName: null,
+        properties: {},
+        metadata: {},
+        aspects: [],
+        tags: [],
+        categories: [],
+        inheritPermissions: true,
+        locked: false,
+        lockedBy: null,
+        previewStatus: null,
+        previewFailureReason: null,
+        previewFailureCategory: null,
+        createdBy: 'admin',
+        createdDate: new Date().toISOString(),
+        lastModifiedBy: 'admin',
+        lastModifiedDate: new Date().toISOString(),
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/security/nodes/*/permissions', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        // Exact EDITOR
+        { authority: 'preset-editor', authorityType: 'USER', permission: 'READ', allowed: true, inherited: false },
+        { authority: 'preset-editor', authorityType: 'USER', permission: 'WRITE', allowed: true, inherited: false },
+        { authority: 'preset-editor', authorityType: 'USER', permission: 'CHECKOUT', allowed: true, inherited: false },
+        { authority: 'preset-editor', authorityType: 'USER', permission: 'CHECKIN', allowed: true, inherited: false },
+        { authority: 'preset-editor', authorityType: 'USER', permission: 'CANCEL_CHECKOUT', allowed: true, inherited: false },
+
+        // Custom user (closest to EDITOR, missing version ops)
+        { authority: 'custom-user', authorityType: 'USER', permission: 'READ', allowed: true, inherited: false },
+        { authority: 'custom-user', authorityType: 'USER', permission: 'WRITE', allowed: true, inherited: false },
+
+        // Exact CONSUMER
+        { authority: 'preset-consumer', authorityType: 'USER', permission: 'READ', allowed: true, inherited: false },
+
+        // Exact CONTRIBUTOR group
+        { authority: 'contributors', authorityType: 'GROUP', permission: 'READ', allowed: true, inherited: true },
+        { authority: 'contributors', authorityType: 'GROUP', permission: 'CREATE_CHILDREN', allowed: true, inherited: true },
+        { authority: 'contributors', authorityType: 'GROUP', permission: 'CHECKOUT', allowed: true, inherited: true },
+        { authority: 'contributors', authorityType: 'GROUP', permission: 'CHECKIN', allowed: true, inherited: true },
+        { authority: 'contributors', authorityType: 'GROUP', permission: 'CANCEL_CHECKOUT', allowed: true, inherited: true },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/security/permission-sets/metadata', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          name: 'COORDINATOR',
+          label: 'Coordinator',
+          description: 'Full control including permission changes',
+          order: 1,
+          permissions: [
+            'READ',
+            'WRITE',
+            'DELETE',
+            'CREATE_CHILDREN',
+            'DELETE_CHILDREN',
+            'EXECUTE',
+            'CHANGE_PERMISSIONS',
+            'TAKE_OWNERSHIP',
+            'CHECKOUT',
+            'CHECKIN',
+            'CANCEL_CHECKOUT',
+            'APPROVE',
+            'REJECT',
+          ],
+        },
+        {
+          name: 'EDITOR',
+          label: 'Editor',
+          description: 'Edit content and manage versions',
+          order: 2,
+          permissions: ['READ', 'WRITE', 'CHECKOUT', 'CHECKIN', 'CANCEL_CHECKOUT'],
+        },
+        {
+          name: 'CONTRIBUTOR',
+          label: 'Contributor',
+          description: 'Create content and add versions',
+          order: 3,
+          permissions: ['READ', 'CREATE_CHILDREN', 'CHECKOUT', 'CHECKIN', 'CANCEL_CHECKOUT'],
+        },
+        {
+          name: 'CONSUMER',
+          label: 'Consumer',
+          description: 'Read-only access',
+          order: 4,
+          permissions: ['READ'],
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/api/v1/security/permission-sets', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        COORDINATOR: [
+          'READ',
+          'WRITE',
+          'DELETE',
+          'CREATE_CHILDREN',
+          'DELETE_CHILDREN',
+          'EXECUTE',
+          'CHANGE_PERMISSIONS',
+          'TAKE_OWNERSHIP',
+          'CHECKOUT',
+          'CHECKIN',
+          'CANCEL_CHECKOUT',
+          'APPROVE',
+          'REJECT',
+        ],
+        EDITOR: ['READ', 'WRITE', 'CHECKOUT', 'CHECKIN', 'CANCEL_CHECKOUT'],
+        CONTRIBUTOR: ['READ', 'CREATE_CHILDREN', 'CHECKOUT', 'CHECKIN', 'CANCEL_CHECKOUT'],
+        CONSUMER: ['READ'],
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/security/permission-templates', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+  });
+
+  await page.route('**/api/v1/security/nodes/*/permission-diagnostics**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        nodeId,
+        username: 'admin',
+        permission: 'READ',
+        allowed: true,
+        reason: 'ADMIN',
+        dynamicAuthority: null,
+        allowedAuthorities: [],
+        deniedAuthorities: [],
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/users**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ content: [], totalElements: 0, totalPages: 0, number: 0, size: 100 }),
+    });
+  });
+
+  await page.route('**/api/v1/groups**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ content: [], totalElements: 0, totalPages: 0, number: 0, size: 100 }),
+    });
+  });
+
+  await page.route('**/api/v1/favorites/batch/check', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ favoritedNodeIds: [] }),
+    });
+  });
+
+  // When running against a static build server (no SPA rewrite), avoid deep links.
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('button', { name: 'Account menu' })).toBeVisible();
+
+  const actionButton = page.getByLabel(`Actions for ${nodeName}`).first();
+  await expect(actionButton).toBeVisible();
+  await actionButton.click();
+  await page.getByRole('menuitem', { name: 'Permissions' }).click();
+
+  const dialog = page.getByRole('dialog').filter({ hasText: 'Manage Permissions' });
+  await expect(dialog).toBeVisible({ timeout: 60_000 });
+  await expect(dialog.getByText('Permission presets (Alfresco-style)')).toBeVisible();
+  await expect(dialog.getByText(/Presets map common roles/i)).toBeVisible();
+
+  const editorRow = dialog.locator('tr', { hasText: 'preset-editor' });
+  await expect(editorRow).toBeVisible();
+  await expect(editorRow.getByRole('cell').nth(1)).toContainText('Editor');
+
+  const customRow = dialog.locator('tr', { hasText: 'custom-user' });
+  await expect(customRow).toBeVisible();
+  await expect(customRow.getByRole('cell').nth(1)).toContainText('Custom');
+  await expect(customRow.getByRole('cell').nth(1)).toContainText('Closest: Editor');
+
+  const consumerRow = dialog.locator('tr', { hasText: 'preset-consumer' });
+  await expect(consumerRow).toBeVisible();
+  await expect(consumerRow.getByRole('cell').nth(1)).toContainText('Consumer');
+
+  await dialog.getByRole('tab', { name: 'Groups' }).click();
+  const groupRow = dialog.locator('tr', { hasText: 'contributors' });
+  await expect(groupRow).toBeVisible();
+  await expect(groupRow.getByRole('cell').nth(1)).toContainText('Contributor');
+});

--- a/ecm-frontend/e2e/phase5-fullstack-admin-smoke.spec.ts
+++ b/ecm-frontend/e2e/phase5-fullstack-admin-smoke.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+import { waitForApiReady } from './helpers/api';
+import { loginWithCredentialsE2E } from './helpers/login';
+
+test('Phase 5 full-stack: admin pages render (Mail Automation + Preview Diagnostics)', async ({ page }) => {
+  test.setTimeout(180_000);
+
+  const username = process.env.ECM_E2E_USERNAME || 'admin';
+  const password = process.env.ECM_E2E_PASSWORD || 'admin';
+
+  // Avoid flakiness when the stack is still starting.
+  await waitForApiReady(page.request);
+
+  await loginWithCredentialsE2E(page, username, password);
+
+  await page.goto('/admin/mail', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('heading', { name: 'Mail Automation' })).toBeVisible();
+
+  await page.goto('/admin/preview-diagnostics', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('heading', { name: 'Preview Diagnostics' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Refresh' })).toBeVisible();
+});
+

--- a/ecm-frontend/e2e/search-fallback-criteria.spec.ts
+++ b/ecm-frontend/e2e/search-fallback-criteria.spec.ts
@@ -85,7 +85,12 @@ test.describe('Search fallback criteria guard', () => {
     await quickSearchInput.press('Enter');
     await searchResponsePromise;
 
-    await expect(page.locator('text=0 results found')).toBeVisible({ timeout: 60_000 });
+    const hidePreviousResultsButton = page.getByRole('button', { name: 'Hide previous results' });
+    if (await hidePreviousResultsButton.isVisible().catch(() => false)) {
+      await hidePreviousResultsButton.click();
+    }
+
+    await expect(page.getByText(/0 (similar )?results found/i)).toBeVisible({ timeout: 60_000 });
     await expect(page.locator('text=No results found')).toBeVisible({ timeout: 60_000 });
     await expect(page.locator('text=Search results may still be indexing')).toHaveCount(0);
     await expect(page.locator('.MuiCard-root').filter({ hasText: filename })).toHaveCount(0);

--- a/ecm-frontend/e2e/search-preview-status.spec.ts
+++ b/ecm-frontend/e2e/search-preview-status.spec.ts
@@ -123,6 +123,37 @@ async function uploadInvalidPdfFile(
   return documentId;
 }
 
+async function uploadDwgFile(
+  request: APIRequestContext,
+  folderId: string,
+  filename: string,
+  token: string,
+) {
+  const uploadRes = await request.post(`${baseApiUrl}/api/v1/documents/upload?folderId=${folderId}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      multipart: {
+        file: {
+          name: filename,
+          mimeType: 'application/octet-stream',
+          buffer: Buffer.from([1, 2, 3, 4, 5]),
+        },
+      },
+    });
+  // DWG parsing can fail during text extraction but still create a document record.
+  // Accept both (2xx) and 400 as long as we get a document id back.
+  const status = uploadRes.status();
+  const uploadJson = (await uploadRes.json().catch(() => ({}))) as { documentId?: string; id?: string };
+  const documentId = uploadJson.documentId ?? uploadJson.id;
+  if (!documentId) {
+    throw new Error('Upload did not return document id');
+  }
+  if (!(uploadRes.ok() || status === 400)) {
+    throw new Error(`Upload failed: status=${status}`);
+  }
+  return documentId;
+}
+
 test('Search preview status filters are visible and selectable', async ({ page, request }) => {
   test.setTimeout(240_000);
   await waitForApiReady(request, { apiUrl: baseApiUrl });
@@ -257,7 +288,9 @@ test('Permanent preview failure hides retry and force rebuild actions in search 
 
   const folderName = `e2e-preview-failed-${Date.now()}`;
   const folderId = await createFolder(request, documentsId, folderName, token);
-  const filename = `e2e-preview-failed-${Date.now()}.pdf`;
+  // Use alpha-only tokens to avoid fuzzy/n-gram matches with prior runs.
+  const tokenPrefix = `pwsrv${randomLetters(16)}`;
+  const filename = `${tokenPrefix}-${Date.now()}.pdf`;
   const documentId = await uploadInvalidPdfFile(request, folderId, filename, token);
 
   const previewRes = await request.get(`${baseApiUrl}/api/v1/documents/${documentId}/preview`, {
@@ -441,6 +474,69 @@ test('Advanced search keeps unsupported filter and hides retry actions for unsup
   await expect(page.getByRole('button', { name: /Retry \".+\" \(\d+\)/i })).toHaveCount(0);
   if (await resultCard.count()) {
     await expect(resultCard.getByRole('button', { name: /Retry preview/i })).toHaveCount(0);
+  }
+
+  await request.delete(`${baseApiUrl}/api/v1/nodes/${folderId}`,
+    { headers: { Authorization: `Bearer ${token}` } }).catch(() => null);
+});
+
+test('CAD preview not configured is treated as UNSUPPORTED and hides retry actions', async ({ page, request }) => {
+  test.setTimeout(240_000);
+  await waitForApiReady(request, { apiUrl: baseApiUrl });
+  const token = await fetchAccessToken(request, defaultUsername, defaultPassword);
+  const rootId = await getRootFolderId(request, token, { apiUrl: baseApiUrl });
+  const documentsId = await findChildFolderId(request, rootId, 'Documents', token, { apiUrl: baseApiUrl });
+
+  const tokenPrefix = `pwsrv${randomLetters(16)}`;
+  const folderName = `e2e-cad-preview-${Date.now()}`;
+  const folderId = await createFolder(request, documentsId, folderName, token);
+  const filename = `${tokenPrefix}-${Date.now()}.dwg`;
+  const documentId = await uploadDwgFile(request, folderId, filename, token);
+
+  const previewRes = await request.get(`${baseApiUrl}/api/v1/documents/${documentId}/preview`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  expect(previewRes.ok()).toBeTruthy();
+  const previewJson = (await previewRes.json()) as { supported?: boolean; status?: string; failureCategory?: string; failureReason?: string };
+  if (previewJson.supported) {
+    test.skip(true, 'CAD render service is configured and reachable; failure semantics are not applicable.');
+  }
+  expect(previewJson.supported).toBe(false);
+  const effectiveStatus = (previewJson.status || '').toUpperCase();
+  const effectiveCategory = (previewJson.failureCategory || '').toUpperCase();
+  const retryable = effectiveStatus === 'FAILED' && effectiveCategory === 'TEMPORARY';
+  if (effectiveStatus === 'UNSUPPORTED') {
+    expect(effectiveCategory).toBe('UNSUPPORTED');
+    expect(previewJson.failureReason || '').toMatch(/CAD preview (disabled|service not configured)/i);
+  } else {
+    expect(effectiveStatus).toBe('FAILED');
+    // When the CAD render service is configured but unhealthy/unreachable, this should be retryable.
+    // Allow a PERMANENT fallback in case the error message has no transient hints.
+    expect(['TEMPORARY', 'PERMANENT']).toContain(effectiveCategory);
+  }
+
+  const indexRes = await request.post(`${baseApiUrl}/api/v1/search/index/${documentId}`,
+    { headers: { Authorization: `Bearer ${token}` } });
+  expect(indexRes.ok()).toBeTruthy();
+  await waitForSearchIndex(request, filename, token, { apiUrl: baseApiUrl, maxAttempts: 40 });
+
+  await gotoWithAuthE2E(page, '/search-results', defaultUsername, defaultPassword, { token });
+
+  const quickSearchInput = page.getByPlaceholder('Quick search by name...');
+  await quickSearchInput.fill(filename);
+  await quickSearchInput.press('Enter');
+
+  const resultCard = page.locator('.MuiCard-root').filter({ hasText: filename }).first();
+  await expect(resultCard).toBeVisible({ timeout: 60_000 });
+  if (effectiveStatus === 'UNSUPPORTED') {
+    await expect(resultCard.getByText(/Preview unsupported/i)).toBeVisible();
+    await expect(resultCard.getByRole('button', { name: /Preview failure reason/i })).toHaveCount(0);
+    await expect(resultCard.getByRole('button', { name: /Retry preview/i })).toHaveCount(0);
+    await expect(resultCard.getByRole('button', { name: /Force rebuild preview/i })).toHaveCount(0);
+  } else {
+    await expect(resultCard.getByText(/Preview failed/i)).toBeVisible();
+    await expect(resultCard.getByRole('button', { name: /Retry preview/i })).toHaveCount(retryable ? 1 : 0);
+    await expect(resultCard.getByRole('button', { name: /Force rebuild preview/i })).toHaveCount(retryable ? 1 : 0);
   }
 
   await request.delete(`${baseApiUrl}/api/v1/nodes/${folderId}`,

--- a/ecm-frontend/e2e/search-suggestions-save-search.mock.spec.ts
+++ b/ecm-frontend/e2e/search-suggestions-save-search.mock.spec.ts
@@ -1,0 +1,181 @@
+import { expect, test } from '@playwright/test';
+import { seedBypassSessionE2E } from './helpers/login';
+
+test('Search: spellcheck "Did you mean" + Save Search (mocked API)', async ({ page }) => {
+  test.setTimeout(120_000);
+
+  await seedBypassSessionE2E(page, 'admin', 'e2e-token');
+
+  const now = new Date().toISOString();
+  const rootFolderId = 'root-folder-id';
+  const misspelling = 'teest';
+  const suggestion = 'test';
+
+  const json = (body: unknown) => JSON.stringify(body);
+  const fulfillJson = (route: any, body: unknown) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: json(body),
+  });
+
+  await page.route('**/api/v1/**', async (route) => {
+    const requestUrl = new URL(route.request().url());
+    const pathname = requestUrl.pathname;
+
+    // File browser boot (app root)
+    if (pathname.endsWith('/folders/roots')) {
+      await fulfillJson(route, [
+        {
+          id: rootFolderId,
+          name: 'Root',
+          path: '/Root',
+          folderType: 'SYSTEM',
+          parentId: null,
+          inheritPermissions: true,
+          description: null,
+          createdBy: 'admin',
+          createdDate: now,
+          lastModifiedBy: 'admin',
+          lastModifiedDate: now,
+        },
+      ]);
+      return;
+    }
+    if (pathname.includes('/folders/') && pathname.endsWith('/contents')) {
+      await fulfillJson(route, { content: [], totalElements: 0, totalPages: 1, number: 0, size: 50 });
+      return;
+    }
+    if (pathname.endsWith('/favorites/batch/check')) {
+      await fulfillJson(route, { favoritedNodeIds: [] });
+      return;
+    }
+
+    // Search dialog / saved searches
+    if (pathname.endsWith('/search/suggestions')) {
+      await fulfillJson(route, []);
+      return;
+    }
+    if (pathname.endsWith('/search/saved') && route.request().method() === 'GET') {
+      await fulfillJson(route, []);
+      return;
+    }
+    if (pathname.endsWith('/search/saved') && route.request().method() === 'POST') {
+      const payload = route.request().postDataJSON?.() as any;
+      expect(payload?.name).toBe('e2e-saved-search');
+      expect(payload?.queryParams).toBeTruthy();
+      await fulfillJson(route, {
+        id: 'saved-1',
+        userId: 'e2e-admin',
+        name: payload.name,
+        queryParams: payload.queryParams,
+        pinned: false,
+        createdAt: now,
+      });
+      return;
+    }
+
+    // Search results
+    if (pathname.endsWith('/search') && route.request().method() === 'GET') {
+      const q = requestUrl.searchParams.get('q') || '';
+      if (q === misspelling) {
+        await fulfillJson(route, { content: [], totalElements: 0 });
+        return;
+      }
+      if (q === suggestion) {
+        await fulfillJson(route, {
+          content: [
+            {
+              id: 'doc-1',
+              name: 'demo.txt',
+              path: '/Root/Documents/demo.txt',
+              nodeType: 'DOCUMENT',
+              parentId: rootFolderId,
+              mimeType: 'text/plain',
+              fileSize: 123,
+              createdBy: 'admin',
+              createdDate: now,
+              lastModifiedBy: 'admin',
+              lastModifiedDate: now,
+              score: 1.0,
+              highlights: { name: ['demo.txt'] },
+              matchFields: ['name'],
+            },
+          ],
+          totalElements: 1,
+        });
+        return;
+      }
+      await fulfillJson(route, { content: [], totalElements: 0 });
+      return;
+    }
+    if (pathname.endsWith('/search/facets')) {
+      await fulfillJson(route, {});
+      return;
+    }
+    if (pathname.endsWith('/search/filters/suggested')) {
+      await fulfillJson(route, []);
+      return;
+    }
+    if (pathname.endsWith('/search/spellcheck')) {
+      const q = requestUrl.searchParams.get('q') || '';
+      if (q === misspelling) {
+        await fulfillJson(route, [suggestion]);
+        return;
+      }
+      await fulfillJson(route, []);
+      return;
+    }
+    if (pathname.endsWith('/search/diagnostics')) {
+      await fulfillJson(route, {
+        username: 'admin',
+        admin: true,
+        readFilterApplied: false,
+        authorityCount: 1,
+        authoritySample: ['ROLE_ADMIN'],
+        note: null,
+        generatedAt: now,
+      });
+      return;
+    }
+    if (pathname.endsWith('/search/index/stats')) {
+      await fulfillJson(route, { indexName: 'ecm_documents', documentCount: 0, searchEnabled: true });
+      return;
+    }
+    if (pathname.endsWith('/search/index/rebuild/status')) {
+      await fulfillJson(route, { inProgress: false, documentsIndexed: 0 });
+      return;
+    }
+
+    await route.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: json({ message: `Not mocked: ${pathname}` }),
+    });
+  });
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('button', { name: 'Search' })).toBeVisible();
+  await page.getByRole('button', { name: 'Search' }).click();
+
+  const searchDialog = page.getByRole('dialog', { name: 'Advanced Search' });
+  await expect(searchDialog).toBeVisible();
+
+  await searchDialog.getByLabel('Name contains').fill(misspelling);
+
+  // Save current criteria as a saved search.
+  await searchDialog.getByRole('button', { name: 'Save Search' }).click();
+  const saveDialog = page.getByRole('dialog', { name: 'Save Search' });
+  await expect(saveDialog).toBeVisible();
+  await saveDialog.getByLabel('Name').fill('e2e-saved-search');
+  await saveDialog.getByRole('button', { name: 'Save' }).click();
+  await expect(saveDialog).toBeHidden({ timeout: 60_000 });
+
+  // Run the search and assert spellcheck suggestions are surfaced.
+  await searchDialog.getByRole('button', { name: 'Search', exact: true }).click();
+
+  await expect(page.getByText('Did you mean')).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByRole('button', { name: suggestion })).toBeVisible();
+
+  await page.getByRole('button', { name: suggestion }).click();
+  await expect(page.getByRole('heading', { name: 'demo.txt' })).toBeVisible({ timeout: 60_000 });
+});

--- a/ecm-frontend/e2e/version-history-paging-major-only.mock.spec.ts
+++ b/ecm-frontend/e2e/version-history-paging-major-only.mock.spec.ts
@@ -1,0 +1,206 @@
+import { expect, test } from '@playwright/test';
+import { seedBypassSessionE2E } from './helpers/login';
+
+test('Version history supports paging and major-only toggle (mocked API)', async ({ page }) => {
+  test.setTimeout(120_000);
+
+  await seedBypassSessionE2E(page, 'admin', 'e2e-token');
+
+  const rootFolderId = 'root-folder-id';
+  const docId = '22222222-2222-2222-2222-222222222222';
+  const now = new Date().toISOString();
+
+  const json = (body: unknown) => JSON.stringify(body);
+  const fulfillJson = (route: any, body: unknown) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: json(body),
+  });
+
+  await page.route('**/api/v1/**', async (route) => {
+    const requestUrl = new URL(route.request().url());
+    const pathname = requestUrl.pathname;
+
+    if (pathname.endsWith('/folders/roots')) {
+      await fulfillJson(route, [
+        {
+          id: rootFolderId,
+          name: 'Root',
+          path: '/Root',
+          folderType: 'SYSTEM',
+          parentId: null,
+          inheritPermissions: true,
+          description: null,
+          createdBy: 'admin',
+          createdDate: now,
+          lastModifiedBy: 'admin',
+          lastModifiedDate: now,
+        },
+      ]);
+      return;
+    }
+
+    if (pathname.includes('/folders/') && pathname.endsWith('/contents')) {
+      await fulfillJson(route, {
+        content: [
+          {
+            id: docId,
+            name: 'demo.txt',
+            description: null,
+            path: '/Root/Documents/demo.txt',
+            nodeType: 'DOCUMENT',
+            parentId: rootFolderId,
+            size: 200,
+            createdBy: 'admin',
+            createdDate: now,
+            lastModifiedBy: 'admin',
+            lastModifiedDate: now,
+            contentType: 'text/plain',
+          },
+        ],
+        totalElements: 1,
+        totalPages: 1,
+        number: 0,
+        size: 50,
+      });
+      return;
+    }
+
+    if (pathname.endsWith('/favorites/batch/check')) {
+      await fulfillJson(route, { favoritedNodeIds: [] });
+      return;
+    }
+
+    if (pathname.endsWith(`/documents/${docId}/versions/paged`)) {
+      const pageParam = requestUrl.searchParams.get('page');
+      const sizeParam = requestUrl.searchParams.get('size');
+      const majorOnlyParam = requestUrl.searchParams.get('majorOnly');
+
+      expect(sizeParam).toBeTruthy();
+
+      const pageNum = pageParam ? Number.parseInt(pageParam, 10) : 0;
+      const majorOnly = majorOnlyParam === 'true';
+
+      // When majorOnly is enabled we only return major versions.
+      if (majorOnly) {
+        expect(pageNum).toBe(0);
+        await fulfillJson(route, {
+          content: [
+            {
+              id: 'v10',
+              documentId: docId,
+              versionLabel: '1.0',
+              comment: 'Major milestone',
+              createdDate: now,
+              creator: 'admin',
+              size: 100,
+              major: true,
+              mimeType: 'text/plain',
+              contentHash: 'hash-v10',
+              contentId: 'content-v10',
+              status: 'OK',
+            },
+          ],
+          totalElements: 1,
+          totalPages: 1,
+          number: 0,
+          size: Number.parseInt(sizeParam || '20', 10),
+        });
+        return;
+      }
+
+      if (pageNum === 0) {
+        await fulfillJson(route, {
+          content: [
+            {
+              id: 'v12',
+              documentId: docId,
+              versionLabel: '1.2',
+              comment: 'Minor update',
+              createdDate: now,
+              creator: 'admin',
+              size: 120,
+              major: false,
+              mimeType: 'text/plain',
+              contentHash: 'hash-v12',
+              contentId: 'content-v12',
+              status: 'OK',
+            },
+            {
+              id: 'v11',
+              documentId: docId,
+              versionLabel: '1.1',
+              comment: 'Minor update',
+              createdDate: now,
+              creator: 'admin',
+              size: 110,
+              major: false,
+              mimeType: 'text/plain',
+              contentHash: 'hash-v11',
+              contentId: 'content-v11',
+              status: 'OK',
+            },
+          ],
+          totalElements: 3,
+          totalPages: 1,
+          number: 0,
+          size: Number.parseInt(sizeParam || '20', 10),
+        });
+        return;
+      }
+
+      // Page 1 appends older versions
+      await fulfillJson(route, {
+        content: [
+          {
+            id: 'v10',
+            documentId: docId,
+            versionLabel: '1.0',
+            comment: 'Major milestone',
+            createdDate: now,
+            creator: 'admin',
+            size: 100,
+            major: true,
+            mimeType: 'text/plain',
+            contentHash: 'hash-v10',
+            contentId: 'content-v10',
+            status: 'OK',
+          },
+        ],
+        totalElements: 3,
+        totalPages: 1,
+        number: 1,
+        size: Number.parseInt(sizeParam || '20', 10),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: json({ message: `Not mocked: ${pathname}` }),
+    });
+  });
+
+  // When running against a static build server (no SPA rewrite), avoid deep links.
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.waitForURL(/\/browse\//, { timeout: 60_000 });
+
+  await expect(page.getByText('demo.txt')).toBeVisible({ timeout: 60_000 });
+  await page.getByRole('button', { name: 'Actions for demo.txt' }).click();
+  await page.getByRole('menuitem', { name: 'Version History' }).click();
+
+  const versionsDialog = page.getByRole('dialog').filter({ hasText: 'Version History' });
+  await expect(versionsDialog).toBeVisible({ timeout: 60_000 });
+
+  await expect(versionsDialog.getByText('1.2')).toBeVisible();
+
+  await versionsDialog.getByRole('button', { name: 'Load more' }).click();
+  await expect(versionsDialog.getByText('1.0')).toBeVisible();
+  await expect(versionsDialog.getByText('Major').first()).toBeVisible();
+
+  await versionsDialog.getByRole('checkbox', { name: 'Major versions only' }).click();
+  await expect(versionsDialog.getByText('1.2')).toHaveCount(0);
+  await expect(versionsDialog.getByText('1.0')).toBeVisible();
+});
+

--- a/ecm-frontend/package.json
+++ b/ecm-frontend/package.json
@@ -37,6 +37,7 @@
     "test": "react-scripts test",
     "e2e:install": "playwright install chromium",
     "e2e": "playwright test",
+    "e2e:preview-search:regression": "playwright test e2e/phase5-fullstack-admin-smoke.spec.ts e2e/search-preview-status.spec.ts e2e/advanced-search-fallback-governance.spec.ts e2e/search-fallback-criteria.spec.ts",
     "eject": "react-scripts eject",
     "lint": "eslint src --ext .ts,.tsx",
     "format": "prettier --write src/**/*.{ts,tsx,css}",

--- a/ecm-frontend/src/App.tsx
+++ b/ecm-frontend/src/App.tsx
@@ -26,6 +26,7 @@ import SettingsPage from './pages/SettingsPage';
 import CorrespondentsPage from './pages/CorrespondentsPage';
 import FavoritesPage from './pages/FavoritesPage';
 import SavedSearchesPage from './pages/SavedSearchesPage';
+import PreviewDiagnosticsPage from './pages/PreviewDiagnosticsPage';
 import VersionHistoryDialog from './components/dialogs/VersionHistoryDialog';
 import PermissionsDialog from './components/dialogs/PermissionsDialog';
 import PropertiesDialog from './components/dialogs/PropertiesDialog';
@@ -236,6 +237,16 @@ const App: React.FC = () => {
                 <PrivateRoute requiredRoles={['ROLE_ADMIN']}>
                   <MainLayout>
                     <WebhookSubscriptionsPage />
+                  </MainLayout>
+                </PrivateRoute>
+              }
+            />
+            <Route
+              path="/admin/preview-diagnostics"
+              element={
+                <PrivateRoute requiredRoles={['ROLE_ADMIN']}>
+                  <MainLayout>
+                    <PreviewDiagnosticsPage />
                   </MainLayout>
                 </PrivateRoute>
               }

--- a/ecm-frontend/src/components/layout/MainLayout.tsx
+++ b/ecm-frontend/src/components/layout/MainLayout.tsx
@@ -36,6 +36,7 @@ import {
   Description,
   Link as LinkIcon,
   AdminPanelSettings,
+  Visibility,
   PushPin,
   PushPinOutlined,
 } from '@mui/icons-material';
@@ -374,6 +375,12 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
                     <Settings fontSize="small" />
                   </ListItemIcon>
                   <ListItemText>Admin Dashboard</ListItemText>
+                </MenuItem>
+                <MenuItem onClick={() => navigate('/admin/preview-diagnostics')}>
+                  <ListItemIcon>
+                    <Visibility fontSize="small" />
+                  </ListItemIcon>
+                  <ListItemText>Preview Diagnostics</ListItemText>
                 </MenuItem>
                 <MenuItem onClick={() => navigate('/admin/mail')}>
                   <ListItemIcon>

--- a/ecm-frontend/src/components/preview/DocumentPreview.tsx
+++ b/ecm-frontend/src/components/preview/DocumentPreview.tsx
@@ -104,6 +104,7 @@ type PreviewQueueStatus = {
   queued?: boolean;
   attempts?: number;
   nextAttemptAt?: string;
+  message?: string;
 };
 
 const OFFICE_MIME_TYPES = new Set([
@@ -485,7 +486,11 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
       setPreviewQueueStatus(status);
       setPreviewStatusOverride('PROCESSING');
       setPreviewFailureOverride(null);
-      toast.success(status?.queued ? 'Preview queued' : 'Preview already up to date');
+      if (status?.queued) {
+        toast.success(status?.message || 'Preview queued');
+      } else {
+        toast.info(status?.message || 'Preview already up to date');
+      }
     } catch {
       toast.error('Failed to queue preview generation');
     } finally {

--- a/ecm-frontend/src/pages/AdvancedSearchPage.tsx
+++ b/ecm-frontend/src/pages/AdvancedSearchPage.tsx
@@ -753,9 +753,9 @@ const AdvancedSearchPage: React.FC = () => {
         },
       }));
       if (status?.queued) {
-        toast.success('Preview queued');
+        toast.success(status?.message || 'Preview queued');
       } else {
-        toast.info('Preview already up to date');
+        toast.info(status?.message || 'Preview already up to date');
       }
     } catch {
       toast.error('Failed to queue preview');

--- a/ecm-frontend/src/pages/PreviewDiagnosticsPage.tsx
+++ b/ecm-frontend/src/pages/PreviewDiagnosticsPage.tsx
@@ -1,0 +1,317 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControl,
+  IconButton,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import {
+  Autorenew as RetryIcon,
+  Build as ForceIcon,
+  Refresh as RefreshIcon,
+  Search as SearchIcon,
+} from '@mui/icons-material';
+import { format } from 'date-fns';
+import { toast } from 'react-toastify';
+import { useNavigate } from 'react-router-dom';
+import nodeService from 'services/nodeService';
+import previewDiagnosticsService, { PreviewFailureSample } from 'services/previewDiagnosticsService';
+import {
+  formatPreviewFailureReasonLabel,
+  getFailedPreviewMeta,
+  isRetryablePreviewFailure,
+  summarizeFailedPreviews,
+} from 'utils/previewStatusUtils';
+
+const LIMIT_OPTIONS = [25, 50, 100, 200] as const;
+
+const formatLastUpdated = (raw?: string | null) => {
+  if (!raw) {
+    return '—';
+  }
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) {
+    return raw;
+  }
+  return format(date, 'PPp');
+};
+
+const PreviewDiagnosticsPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [limit, setLimit] = useState<(typeof LIMIT_OPTIONS)[number]>(50);
+  const [filterText, setFilterText] = useState('');
+  const [items, setItems] = useState<PreviewFailureSample[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [queueingId, setQueueingId] = useState<string | null>(null);
+
+  const loadFailures = async () => {
+    try {
+      setLoading(true);
+      const data = await previewDiagnosticsService.listRecentFailures(limit);
+      setItems(Array.isArray(data) ? data : []);
+    } catch {
+      toast.error('Failed to load preview diagnostics (admin required)');
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadFailures();
+  }, [limit]);
+
+  const summary = useMemo(() => {
+    return summarizeFailedPreviews(
+      items.map((item) => ({
+        previewStatus: item.previewStatus,
+        previewFailureCategory: item.previewFailureCategory,
+        previewFailureReason: item.previewFailureReason,
+        mimeType: item.mimeType,
+      }))
+    );
+  }, [items]);
+
+  const filteredItems = useMemo(() => {
+    const query = filterText.trim().toLowerCase();
+    if (!query) {
+      return items;
+    }
+    return items.filter((item) => {
+      const haystacks = [
+        item.name,
+        item.path,
+        item.mimeType,
+        item.previewStatus,
+        item.previewFailureCategory,
+        item.previewFailureReason,
+      ]
+        .filter(Boolean)
+        .map((value) => String(value).toLowerCase());
+      return haystacks.some((value) => value.includes(query));
+    });
+  }, [filterText, items]);
+
+  const handleOpenInSearch = (item: PreviewFailureSample) => {
+    const q = (item.name || '').trim();
+    const encoded = encodeURIComponent(q);
+    navigate(`/search?q=${encoded}`);
+  };
+
+  const handleQueuePreview = async (item: PreviewFailureSample, force: boolean) => {
+    const retryable = isRetryablePreviewFailure(item.previewFailureCategory, item.mimeType, item.previewFailureReason);
+    if (!retryable) {
+      return;
+    }
+    try {
+      setQueueingId(item.id);
+      await nodeService.queuePreview(item.id, force);
+      toast.success(`Preview ${force ? 'rebuild' : 'retry'} queued`);
+      await loadFailures();
+    } catch {
+      toast.error('Failed to queue preview');
+    } finally {
+      setQueueingId(null);
+    }
+  };
+
+  return (
+    <Box p={3}>
+      <Stack direction="row" alignItems="flex-start" justifyContent="space-between" flexWrap="wrap" gap={2} mb={2}>
+        <Box>
+          <Typography variant="h4">Preview Diagnostics</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Recent preview failures (FAILED/UNSUPPORTED) from backend diagnostics.
+          </Typography>
+        </Box>
+        <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
+          <FormControl size="small">
+            <Select
+              aria-label="Preview diagnostics limit"
+              value={limit}
+              onChange={(event) => setLimit(event.target.value as (typeof LIMIT_OPTIONS)[number])}
+            >
+              {LIMIT_OPTIONS.map((option) => (
+                <MenuItem key={option} value={option}>
+                  Limit {option}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <Button
+            variant="outlined"
+            startIcon={<RefreshIcon />}
+            onClick={() => void loadFailures()}
+            disabled={loading}
+          >
+            Refresh
+          </Button>
+        </Stack>
+      </Stack>
+
+      <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap" mb={2}>
+        <TextField
+          size="small"
+          placeholder="Filter by name, path, mime type..."
+          value={filterText}
+          onChange={(event) => setFilterText(event.target.value)}
+          sx={{ minWidth: 320, flex: '1 1 320px' }}
+        />
+        <Chip label={`Total ${summary.totalFailed}`} />
+        <Chip label={`Retryable ${summary.retryableFailed}`} color="warning" variant="outlined" />
+        <Chip label={`Permanent ${summary.permanentFailed}`} color="error" variant="outlined" />
+        <Chip label={`Unsupported ${summary.unsupportedFailed}`} variant="outlined" />
+      </Stack>
+
+      <Paper sx={{ p: 2 }}>
+        {loading ? (
+          <Box display="flex" justifyContent="center" py={6}>
+            <CircularProgress />
+          </Box>
+        ) : filteredItems.length === 0 ? (
+          <Alert severity="info">No preview failures found.</Alert>
+        ) : (
+          <TableContainer>
+            <Table size="small" aria-label="Preview diagnostics failures">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell>Mime Type</TableCell>
+                  <TableCell>Category</TableCell>
+                  <TableCell>Reason</TableCell>
+                  <TableCell>Last Updated</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {filteredItems.map((item) => {
+                  const meta = getFailedPreviewMeta(item.mimeType, item.previewFailureCategory, item.previewFailureReason);
+                  const retryable = isRetryablePreviewFailure(
+                    item.previewFailureCategory,
+                    item.mimeType,
+                    item.previewFailureReason
+                  );
+                  const queueBusy = queueingId === item.id;
+                  const reasonLabel = formatPreviewFailureReasonLabel(item.previewFailureReason);
+
+                  return (
+                    <TableRow key={item.id} hover>
+                      <TableCell sx={{ maxWidth: 360 }}>
+                        <Tooltip title={item.path || item.name || item.id} placement="top-start" arrow>
+                          <Typography variant="body2" noWrap>
+                            {item.name || item.id}
+                          </Typography>
+                        </Tooltip>
+                        {item.path && (
+                          <Typography variant="caption" color="text.secondary" noWrap>
+                            {item.path}
+                          </Typography>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Chip label={meta.label} color={meta.color} size="small" />
+                      </TableCell>
+                      <TableCell sx={{ maxWidth: 220 }}>
+                        <Typography variant="body2" noWrap>
+                          {item.mimeType || '—'}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Chip label={item.previewFailureCategory || '—'} size="small" variant="outlined" />
+                      </TableCell>
+                      <TableCell sx={{ maxWidth: 420 }}>
+                        <Tooltip title={reasonLabel} placement="top-start" arrow>
+                          <Typography variant="body2" noWrap>
+                            {reasonLabel}
+                          </Typography>
+                        </Tooltip>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2">{formatLastUpdated(item.previewLastUpdated)}</Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        <Stack direction="row" justifyContent="flex-end" gap={0.5}>
+                          <Tooltip title="Open in Advanced Search" placement="top-start" arrow>
+                            <IconButton
+                              aria-label="Open in Advanced Search"
+                              size="small"
+                              onClick={() => handleOpenInSearch(item)}
+                            >
+                              <SearchIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+
+                          <Tooltip
+                            title={
+                              retryable
+                                ? 'Retry preview'
+                                : 'Retry is only available for temporary failures (unsupported/permanent are disabled)'
+                            }
+                            placement="top-start"
+                            arrow
+                          >
+                            <span>
+                              <IconButton
+                                aria-label="Retry preview"
+                                size="small"
+                                disabled={!retryable || queueBusy}
+                                onClick={() => void handleQueuePreview(item, false)}
+                              >
+                                <RetryIcon fontSize="small" />
+                              </IconButton>
+                            </span>
+                          </Tooltip>
+
+                          <Tooltip
+                            title={
+                              retryable
+                                ? 'Force rebuild preview'
+                                : 'Force rebuild is only available for temporary failures (unsupported/permanent are disabled)'
+                            }
+                            placement="top-start"
+                            arrow
+                          >
+                            <span>
+                              <IconButton
+                                aria-label="Force rebuild preview"
+                                size="small"
+                                disabled={!retryable || queueBusy}
+                                onClick={() => void handleQueuePreview(item, true)}
+                              >
+                                <ForceIcon fontSize="small" />
+                              </IconButton>
+                            </span>
+                          </Tooltip>
+                        </Stack>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </Paper>
+    </Box>
+  );
+};
+
+export default PreviewDiagnosticsPage;
+

--- a/ecm-frontend/src/pages/SearchResults.tsx
+++ b/ecm-frontend/src/pages/SearchResults.tsx
@@ -1548,9 +1548,9 @@ const SearchResults: React.FC = () => {
         },
       }));
       if (status?.queued) {
-        toast.success('Preview queued');
+        toast.success(status?.message || 'Preview queued');
       } else {
-        toast.info('Preview already up to date');
+        toast.info(status?.message || 'Preview already up to date');
       }
     } catch {
       toast.error('Failed to queue preview');

--- a/ecm-frontend/src/pages/SearchResults.tsx
+++ b/ecm-frontend/src/pages/SearchResults.tsx
@@ -61,7 +61,7 @@ import {
   formatPreviewFailureReasonLabel,
   getEffectivePreviewStatus,
   getFailedPreviewMeta,
-  isUnsupportedPreviewFailure,
+  isRetryablePreviewFailure,
   normalizePreviewFailureReason,
   summarizeFailedPreviews,
 } from 'utils/previewStatusUtils';
@@ -1283,6 +1283,11 @@ const SearchResults: React.FC = () => {
             ? 'info'
             : 'default';
     const failedPreviewUnsupported = (effectiveStatus === 'FAILED' || effectiveStatus === 'UNSUPPORTED') && failedPreviewMeta.unsupported;
+    const failedPreviewRetryable = effectiveStatus === 'FAILED' && isRetryablePreviewFailure(
+      node.previewFailureCategory,
+      nodeMimeType,
+      node.previewFailureReason
+    );
     const queueStatus = previewQueueStatusById[node.id];
     const queueDetail = (() => {
       if (!queueStatus) {
@@ -1318,7 +1323,7 @@ const SearchResults: React.FC = () => {
               </IconButton>
             </Tooltip>
           )}
-          {effectiveStatus === 'FAILED' && !failedPreviewUnsupported && (
+          {effectiveStatus === 'FAILED' && failedPreviewRetryable && (
             <Tooltip title="Retry preview" placement="top-start" arrow>
               <span>
                 <IconButton
@@ -1335,7 +1340,7 @@ const SearchResults: React.FC = () => {
               </span>
             </Tooltip>
           )}
-          {effectiveStatus === 'FAILED' && !failedPreviewUnsupported && (
+          {effectiveStatus === 'FAILED' && failedPreviewRetryable && (
             <Tooltip title="Force rebuild preview" placement="top-start" arrow>
               <span>
                 <IconButton
@@ -1470,7 +1475,7 @@ const SearchResults: React.FC = () => {
   );
   const failedPreviewNodes = displayNodes.filter((node) => node.nodeType === 'DOCUMENT'
     && (node.previewStatus || '').toUpperCase() === 'FAILED'
-    && !isUnsupportedPreviewFailure(
+    && isRetryablePreviewFailure(
       node.previewFailureCategory,
       node.contentType || node.properties?.mimeType || node.properties?.contentType,
       node.previewFailureReason
@@ -2061,11 +2066,20 @@ const SearchResults: React.FC = () => {
                 Preview issues on current page: {failedPreviewSummary.totalFailed}
                 {' • '}Retryable {failedPreviewSummary.retryableFailed}
                 {' • '}Unsupported {failedPreviewSummary.unsupportedFailed}
+                {failedPreviewSummary.permanentFailed > 0 && (
+                  <>
+                    {' • '}Permanent {failedPreviewSummary.permanentFailed}
+                  </>
+                )}
               </Typography>
             )}
             {failedPreviewSummary.totalFailed > 0 && failedPreviewSummary.retryableFailed === 0 && (
               <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
-                All preview issues on this page are unsupported; retry actions are hidden.
+                {failedPreviewSummary.permanentFailed > 0
+                  ? failedPreviewSummary.unsupportedFailed > 0
+                    ? 'All preview issues on this page are permanent or unsupported; retry actions are hidden.'
+                    : 'All preview issues on this page are permanent; retry actions are hidden.'
+                  : 'All preview issues on this page are unsupported; retry actions are hidden.'}
               </Typography>
             )}
             {failedPreviewSummary.retryableFailed > 0 && failedPreviewReasonSummary.length > 0 && (

--- a/ecm-frontend/src/services/nodeService.ts
+++ b/ecm-frontend/src/services/nodeService.ts
@@ -138,6 +138,7 @@ export interface PreviewQueueStatus {
   queued: boolean;
   attempts?: number;
   nextAttemptAt?: string;
+  message?: string | null;
 }
 
 export interface OcrQueueStatus {

--- a/ecm-frontend/src/services/previewDiagnosticsService.ts
+++ b/ecm-frontend/src/services/previewDiagnosticsService.ts
@@ -1,0 +1,22 @@
+import api from './api';
+
+export type PreviewFailureSample = {
+  id: string;
+  name: string;
+  path: string;
+  mimeType: string;
+  previewStatus: string | null;
+  previewFailureReason: string | null;
+  previewFailureCategory: string | null;
+  previewLastUpdated: string | null;
+};
+
+class PreviewDiagnosticsService {
+  async listRecentFailures(limit = 50): Promise<PreviewFailureSample[]> {
+    return api.get<PreviewFailureSample[]>('/preview/diagnostics/failures', { params: { limit } });
+  }
+}
+
+const previewDiagnosticsService = new PreviewDiagnosticsService();
+export default previewDiagnosticsService;
+

--- a/scripts/phase5-fullstack-smoke.sh
+++ b/scripts/phase5-fullstack-smoke.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ECM_API_URL="${ECM_API_URL:-http://localhost:7700}"
+KEYCLOAK_URL="${KEYCLOAK_URL:-http://localhost:8180}"
+KEYCLOAK_REALM="${KEYCLOAK_REALM:-ecm}"
+
+# Prefer CRA dev server for full-stack runs (it proxies API requests via package.json "proxy").
+ECM_UI_URL="${ECM_UI_URL:-http://localhost:3000}"
+
+ECM_E2E_USERNAME="${ECM_E2E_USERNAME:-admin}"
+ECM_E2E_PASSWORD="${ECM_E2E_PASSWORD:-admin}"
+
+PW_PROJECT="${PW_PROJECT:-chromium}"
+PW_WORKERS="${PW_WORKERS:-1}"
+
+echo "phase5_fullstack_smoke: start"
+echo "ECM_UI_URL=${ECM_UI_URL}"
+echo "ECM_API_URL=${ECM_API_URL}"
+echo "KEYCLOAK_URL=${KEYCLOAK_URL} KEYCLOAK_REALM=${KEYCLOAK_REALM}"
+echo "PW_PROJECT=${PW_PROJECT} PW_WORKERS=${PW_WORKERS}"
+
+case "${ECM_UI_URL}" in
+  http://localhost:5500*|http://127.0.0.1:5500*)
+    echo "error: ECM_UI_URL points at a static server (:5500) which does not proxy API calls."
+    echo "hint: start the dev server on :3000 or set ECM_UI_URL to a reverse-proxy that forwards /api to :7700"
+    exit 2
+    ;;
+esac
+
+echo "phase5_fullstack_smoke: check backend health"
+curl -fsS --max-time 5 "${ECM_API_URL}/actuator/health" >/dev/null
+
+echo "phase5_fullstack_smoke: check keycloak discovery"
+curl -fsS --max-time 5 "${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/.well-known/openid-configuration" >/dev/null
+
+echo "phase5_fullstack_smoke: check UI reachable"
+curl -fsS --max-time 5 "${ECM_UI_URL}" >/dev/null
+
+echo "phase5_fullstack_smoke: check e2e target"
+scripts/check-e2e-target.sh "${ECM_UI_URL}" || true
+
+if [[ ! -d "ecm-frontend" ]]; then
+  echo "error: missing ecm-frontend/"
+  exit 1
+fi
+
+cd ecm-frontend
+
+echo "phase5_fullstack_smoke: run playwright (full-stack admin smoke)"
+ECM_UI_URL="${ECM_UI_URL}" \
+ECM_API_URL="${ECM_API_URL}" \
+KEYCLOAK_URL="${KEYCLOAK_URL}" \
+KEYCLOAK_REALM="${KEYCLOAK_REALM}" \
+ECM_E2E_USERNAME="${ECM_E2E_USERNAME}" \
+ECM_E2E_PASSWORD="${ECM_E2E_PASSWORD}" \
+npx playwright test \
+  e2e/phase5-fullstack-admin-smoke.spec.ts \
+  --project="${PW_PROJECT}" --workers="${PW_WORKERS}"
+
+echo "phase5_fullstack_smoke: ok"

--- a/scripts/phase5-preview-diagnostics-realchain.sh
+++ b/scripts/phase5-preview-diagnostics-realchain.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Real-chain verification for Admin Preview Diagnostics:
+# - Upload a deliberately corrupted PDF
+# - Wait for preview pipeline to mark it FAILED/UNSUPPORTED
+# - Assert it appears in /api/v1/preview/diagnostics/failures
+#
+# Usage:
+#   bash scripts/phase5-preview-diagnostics-realchain.sh [username] [password]
+#
+# Env overrides:
+#   ECM_API_URL (default http://localhost:7700)
+#   LIMIT (default 200)
+#   POLL_SECONDS (default 120)
+#   POLL_INTERVAL (default 3)
+#   EXPECT_REASON_SUBSTR (optional substring match for previewFailureReason)
+
+USERNAME="${1:-${ECM_E2E_USERNAME:-admin}}"
+PASSWORD="${2:-${ECM_E2E_PASSWORD:-admin}}"
+
+ECM_API_URL="${ECM_API_URL:-http://localhost:7700}"
+LIMIT="${LIMIT:-200}"
+POLL_SECONDS="${POLL_SECONDS:-120}"
+POLL_INTERVAL="${POLL_INTERVAL:-3}"
+EXPECT_REASON_SUBSTR="${EXPECT_REASON_SUBSTR:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "phase5_preview_realchain: start"
+echo "ECM_API_URL=${ECM_API_URL} LIMIT=${LIMIT} POLL_SECONDS=${POLL_SECONDS} POLL_INTERVAL=${POLL_INTERVAL}"
+
+pushd "${ROOT_DIR}" >/dev/null
+bash "${SCRIPT_DIR}/get-token.sh" "${USERNAME}" "${PASSWORD}" >/dev/null
+TOKEN_FILE="tmp/${USERNAME}.access_token"
+TOKEN="$(cat "${TOKEN_FILE}" 2>/dev/null || true)"
+popd >/dev/null
+
+if [[ -z "${TOKEN}" ]]; then
+  echo "ERROR: failed to obtain access token (expected ${TOKEN_FILE})"
+  exit 1
+fi
+
+echo "phase5_preview_realchain: create corrupted pdf"
+TMP_PDF="$(mktemp /tmp/ecm-preview-corrupt.XXXXXX.pdf)"
+cat >"${TMP_PDF}" <<'EOF'
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog >>
+endobj
+trailer
+<< >>
+%%EOF
+EOF
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+NAME="e2e-preview-diagnostics-corrupt-${STAMP}.pdf"
+FILE="/tmp/${NAME}"
+cp -f "${TMP_PDF}" "${FILE}"
+
+echo "phase5_preview_realchain: resolve root folder id"
+roots_json="$(curl -fsS -H "Authorization: Bearer ${TOKEN}" "${ECM_API_URL}/api/v1/folders/roots")"
+root_id="$(echo "${roots_json}" | jq -r '([.[] | select(((.folderType // "") | ascii_upcase)=="SYSTEM" and ((.path // "")=="/Root") and ((.name // "")=="Root"))][0].id) // (.[0].id // empty)')"
+if [[ -z "${root_id}" ]]; then
+  echo "ERROR: failed to resolve root folder id"
+  echo "${roots_json}" | head -c 400 || true
+  echo
+  exit 1
+fi
+echo "root_id=${root_id}"
+
+echo "phase5_preview_realchain: upload corrupted pdf"
+upload_resp="$(curl -fsS -H "Authorization: Bearer ${TOKEN}" \
+  -F "file=@${FILE};type=application/pdf" \
+  "${ECM_API_URL}/api/v1/documents/upload?folderId=${root_id}")"
+
+doc_id="$(echo "${upload_resp}" | jq -r '.documentId // empty')"
+if [[ -z "${doc_id}" ]]; then
+  echo "ERROR: upload did not return documentId"
+  echo "${upload_resp}" | head -c 400 || true
+  echo
+  exit 1
+fi
+echo "uploaded_document_id=${doc_id} name=${NAME}"
+
+echo "phase5_preview_realchain: poll preview failures endpoint for uploaded doc name"
+deadline=$(( $(date +%s) + POLL_SECONDS ))
+last_count=0
+while [[ "$(date +%s)" -lt "${deadline}" ]]; do
+  failures_json="$(curl -fsS -H "Authorization: Bearer ${TOKEN}" "${ECM_API_URL}/api/v1/preview/diagnostics/failures?limit=${LIMIT}" || true)"
+  if [[ -n "${failures_json}" ]]; then
+    last_count="$(echo "${failures_json}" | jq -r 'length' 2>/dev/null || echo 0)"
+    match="$(echo "${failures_json}" | jq -c --arg name "${NAME}" '.[] | select(.name==$name) | {id,name,previewStatus,previewFailureCategory,previewFailureReason,previewLastUpdated}' | head -n 1)"
+    if [[ -n "${match}" ]]; then
+      echo "FOUND: ${match}"
+      if [[ -n "${EXPECT_REASON_SUBSTR}" ]]; then
+        reason="$(echo "${match}" | jq -r '.previewFailureReason // ""')"
+        if [[ "${reason}" != *"${EXPECT_REASON_SUBSTR}"* ]]; then
+          echo "FAIL: previewFailureReason did not include EXPECT_REASON_SUBSTR='${EXPECT_REASON_SUBSTR}'"
+          exit 3
+        fi
+      fi
+      echo "phase5_preview_realchain: ok"
+      exit 0
+    fi
+  fi
+  sleep "${POLL_INTERVAL}"
+done
+
+echo "FAIL: uploaded doc did not appear in preview failures within ${POLL_SECONDS}s (last_failures_count=${last_count})"
+echo "hint: ensure preview pipeline workers are running and the file actually produces a FAILED/UNSUPPORTED status"
+exit 2
+

--- a/scripts/phase5-regression.sh
+++ b/scripts/phase5-regression.sh
@@ -19,6 +19,7 @@ PHASE5_SPECS=(
   "e2e/admin-audit-filter-export.mock.spec.ts"
   "e2e/version-history-paging-major-only.mock.spec.ts"
   "e2e/search-suggestions-save-search.mock.spec.ts"
+  "e2e/mail-automation-trigger-fetch.mock.spec.ts"
 )
 
 if [[ ! -d "ecm-frontend" ]]; then

--- a/scripts/phase5-regression.sh
+++ b/scripts/phase5-regression.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ECM_UI_URL="${ECM_UI_URL:-http://localhost:5500}"
+PW_WORKERS="${PW_WORKERS:-1}"
+PW_PROJECT="${PW_PROJECT:-chromium}"
+
+echo "phase5_regression: start"
+echo "ECM_UI_URL=${ECM_UI_URL}"
+echo "PW_PROJECT=${PW_PROJECT} PW_WORKERS=${PW_WORKERS}"
+
+# This gate is intentionally "mocked-first" so it can run without Docker/backend.
+PHASE5_SPECS=(
+  "e2e/admin-preview-diagnostics.mock.spec.ts"
+  "e2e/permissions-dialog-presets.mock.spec.ts"
+  "e2e/admin-audit-filter-export.mock.spec.ts"
+  "e2e/version-history-paging-major-only.mock.spec.ts"
+  "e2e/search-suggestions-save-search.mock.spec.ts"
+)
+
+if [[ ! -d "ecm-frontend" ]]; then
+  echo "error: missing ecm-frontend/"
+  exit 1
+fi
+
+cd ecm-frontend
+
+echo "phase5_regression: build frontend"
+npm run build
+
+echo "phase5_regression: check e2e target"
+ALLOW_STATIC=1 ../scripts/check-e2e-target.sh "${ECM_UI_URL}" || true
+
+echo "phase5_regression: ensure static server reachable"
+if ! curl -fsS --max-time 3 "${ECM_UI_URL}" >/dev/null 2>&1; then
+  case "${ECM_UI_URL}" in
+    http://localhost:5500*|http://127.0.0.1:5500*)
+      echo "phase5_regression: starting static server on :5500"
+      python3 -m http.server 5500 --directory build >/tmp/phase5-regression.http.log 2>&1 &
+      srv_pid=$!
+      trap 'kill "${srv_pid}" >/dev/null 2>&1 || true' EXIT
+
+      for _ in $(seq 1 20); do
+        if curl -fsS --max-time 1 "${ECM_UI_URL}" >/dev/null 2>&1; then
+          break
+        fi
+        sleep 0.3
+      done
+      ;;
+    *)
+      echo "error: ECM_UI_URL not reachable: ${ECM_UI_URL}"
+      echo "hint: start a server (dev on :3000 or static on :5500) or set ECM_UI_URL accordingly"
+      exit 1
+      ;;
+  esac
+fi
+
+echo "phase5_regression: run playwright specs"
+ECM_UI_URL="${ECM_UI_URL}" npx playwright test \
+  "${PHASE5_SPECS[@]}" \
+  --project="${PW_PROJECT}" --workers="${PW_WORKERS}"
+
+echo "phase5_regression: ok"

--- a/scripts/phase5-regression.sh
+++ b/scripts/phase5-regression.sh
@@ -31,9 +31,6 @@ cd ecm-frontend
 echo "phase5_regression: build frontend"
 npm run build
 
-echo "phase5_regression: check e2e target"
-ALLOW_STATIC=1 ../scripts/check-e2e-target.sh "${ECM_UI_URL}" || true
-
 echo "phase5_regression: ensure static server reachable"
 if ! curl -fsS --max-time 3 "${ECM_UI_URL}" >/dev/null 2>&1; then
   case "${ECM_UI_URL}" in
@@ -57,6 +54,9 @@ if ! curl -fsS --max-time 3 "${ECM_UI_URL}" >/dev/null 2>&1; then
       ;;
   esac
 fi
+
+echo "phase5_regression: check e2e target"
+ALLOW_STATIC=1 ../scripts/check-e2e-target.sh "${ECM_UI_URL}" || true
 
 echo "phase5_regression: run playwright specs"
 ECM_UI_URL="${ECM_UI_URL}" npx playwright test \

--- a/scripts/phase5-regression.sh
+++ b/scripts/phase5-regression.sh
@@ -21,6 +21,7 @@ PHASE5_SPECS=(
   "e2e/search-suggestions-save-search.mock.spec.ts"
   "e2e/mail-automation-trigger-fetch.mock.spec.ts"
   "e2e/mail-automation-diagnostics-export.mock.spec.ts"
+  "e2e/mail-automation-processed-management.mock.spec.ts"
 )
 
 if [[ ! -d "ecm-frontend" ]]; then

--- a/scripts/phase5-regression.sh
+++ b/scripts/phase5-regression.sh
@@ -20,6 +20,7 @@ PHASE5_SPECS=(
   "e2e/version-history-paging-major-only.mock.spec.ts"
   "e2e/search-suggestions-save-search.mock.spec.ts"
   "e2e/mail-automation-trigger-fetch.mock.spec.ts"
+  "e2e/mail-automation-diagnostics-export.mock.spec.ts"
 )
 
 if [[ ! -d "ecm-frontend" ]]; then


### PR DESCRIPTION
## Summary
This PR hardens local/full-stack stability for preview/search regression work and wires a dedicated regression gate into CI.

### Changes
- Fix `ecm-core` startup in container when running as `app` user:
  - use resolved absolute Java binary in `entrypoint.sh`.
- Make JODConverter enablement overridable in compose:
  - `JODCONVERTER_LOCAL_ENABLED=${JODCONVERTER_LOCAL_ENABLED:-true}`.
- Stabilize fallback-governance E2E assertion:
  - if stale fallback panel appears, click **Hide previous results** before asserting empty state.
- Add reusable regression entrypoint:
  - `npm run e2e:preview-search:regression`.
- Add dual local restart modes:
  - `scripts/restart-ecm.sh --mode fast|full` (`--fast`, `--full`).
- CI integration:
  - add preview/search regression gate step to `frontend_e2e_core`.
  - keep artifact upload on failure.
  - increase job timeout to 120 min.
- Docs:
  - `docs/DESIGN_PREVIEW_SEARCH_STABILITY_20260214.md`
  - `docs/DEVELOPMENT_VERIFICATION_PREVIEW_SEARCH_STABILITY_20260214.md`

## Validation
- Service health:
  - `curl http://localhost:7700/actuator/health` => `{"status":"UP"}`
  - `curl -I http://127.0.0.1:5500` => `200`
- E2E:
  - `npm run e2e:preview-search:regression -- --reporter=line`
  - result: **12 passed**
- Script checks:
  - `bash scripts/restart-ecm.sh --help`
  - `bash -n scripts/restart-ecm.sh`

## Notes
- `fast` mode is for developer iteration speed (skip LibreOffice image payload).
- `full` mode keeps local office conversion behavior for parity checks.
