### PR TITLE
docs(license): gap audit + correct FEATURE_LICENSING.md (placeholder, not enforced)

### DIFF
--- a/docs/FEATURE_LICENSING.md
+++ b/docs/FEATURE_LICENSING.md
@@ -1,37 +1,39 @@
 # 功能开发报告：商业授权许可 (Licensing)
 
-> **版本**: 1.0
-> **日期**: 2025-12-10
-> **状态**: ✅ 已完成 (基础框架)
+> **版本**: 1.1
+> **日期**: 2025-12-10（2026-06-23 状态纠偏）
+> **状态**: ⚠️ **Placeholder / 占位实现** —— 校验逻辑为 mock（硬编码），限制执行（`checkUserLimit` / `isFeatureEnabled`）**未接入、为死代码（NOT enforced yet）**。read-only 复核见 `docs/GAP_AUDIT_LICENSE_ENTITLEMENT_ADMIN_20260623.md`。
 
 ## 1. 概述
 
-为了支持 Athena ECM 的商业化运作（如提供企业版 Enterprise Edition），我们需要一个基础的授权许可管理模块。该模块负责验证系统的使用权限，并根据 License 限制系统资源的使用。
+为支持 Athena ECM 的商业化（如企业版 Enterprise Edition），原计划提供一个授权许可模块，验证使用权限并按 License 限制资源使用。**当前实现仅为占位**：校验是 mock，限制执行尚未接入任何代码路径，`/api/v1/system/license` 仅供 Admin Dashboard 只读展示。
 
-## 2. 核心功能实现
+## 2. 现状（2026-06-23 实查）
 
 ### 2.1 License Service (`LicenseService`)
 
-*   **启动检查**: 系统启动时自动读取配置文件中的 `ecm.license.key`。
-*   **验证逻辑**:
-    *   如果没有 Key，自动降级为 **Community Edition**（限制 5 用户，10GB 存储）。
-    *   如果有 Key，解析并验证（模拟验证逻辑，生产环境应使用 RSA 签名校验）。
-*   **限制执行**:
-    *   `checkUserLimit()`: 在创建新用户时调用，超过限制则抛出异常。
-    *   `isFeatureEnabled(feature)`: 用于代码中判断是否开启高级功能（如多租户、高级审计）。
+*   **启动检查**: 系统启动时读取 `ecm.license.key`。
+*   **验证逻辑（⚠️ mock，非真验签）**:
+    *   没有 Key → 降级为 **Community Edition**（5 用户 / 10GB / 永不过期 / `[BASIC]`）。
+    *   有 Key → **当前并不真正解析或验签**：任何非空且非 `"invalid"` 的 Key 一律硬编码为 **Enterprise**（100 用户 / 1000GB / +1 年 / `[WORKFLOW,OCR,AUDIT]`）；`"invalid"` 或异常一律回退 Community。代码导入了 JWT/RSA 却未使用。`valid` 对外**恒为 `true`**。
+*   **限制执行（⚠️ 当前未接入 / NOT ENFORCED YET —— 死代码）**:
+    *   `checkUserLimit()`: 已定义，但**全仓无生产调用者**——用户上限当前并不执行。
+    *   `isFeatureEnabled(feature)`: 已定义，但**全仓无生产调用者**——没有任何功能受 License 开关控制；feature 名仅为 `LicenseService` 内的字符串字面量，无枚举 / 注册表。
+    *   （`rg` 复核 2026-06-23：两方法仅在 `LicenseService.java:89 / :104` 定义，无 caller。）
 
 ### 2.2 API 接口
 
 | 方法 | 路径 | 描述 |
 |------|------|------|
-| GET | `/api/v1/system/license` | 获取当前 License 信息（仅限管理员） |
+| GET | `/api/v1/system/license` | 获取当前 License 信息（仅限管理员，只读展示） |
 
-## 3. 验证方法
+## 3. 验证方法（当前行为）
 
-1.  **默认状态**: 不配置 License Key，启动系统。调用接口应返回 "Community" 版本，且 `maxUsers` 为 5。
-2.  **配置 License**: 在 `application.yml` 或环境变量中设置 `ECM_LICENSE_KEY=valid`。重启系统，调用接口应返回 "Enterprise" 版本，且限制放宽。
+1.  **默认状态**: 不配置 License Key → 接口返回 "Community"、`maxUsers=5`。
+2.  **配置 License**: 设置任意非空且非 `invalid` 的 `ECM_LICENSE_KEY`（如 `valid`）→ 接口返回硬编码的 "Enterprise" 信息。**注意：这是 mock 数据，限制并未真正执行**（见 §2.1）。
 
-## 4. 后续计划
+## 4. 后续计划（若 licensing 成为真需求）
 
-*   **RSA 签名**: 实现完整的公私钥签发和验证机制，防止 License 被篡改。
-*   ✅ **前端展示已完成**: Admin Dashboard 增加 License 区块，展示 Edition/有效性/限制/到期时间/Features。
+*   **RSA 签名**: 实现真正的公私钥签发与验签，防止 License 被篡改。
+*   **限制执行接入**: 将 `checkUserLimit` / `isFeatureEnabled` 接进 create-user / feature 路径（当前为死代码、无 caller）。
+*   ✅ **前端展示已完成**: Admin Dashboard 已有 License 区块（展示 Edition / 有效性 / 限制 / 到期 / Features）——注意它展示的是上述 **mock 数据**。

--- a/docs/GAP_AUDIT_LICENSE_ENTITLEMENT_ADMIN_20260623.md
+++ b/docs/GAP_AUDIT_LICENSE_ENTITLEMENT_ADMIN_20260623.md
@@ -1,0 +1,75 @@
+# License/Entitlement Admin — Gap Audit
+
+Status: **GAP AUDIT — for owner ratify. NO code yet.** Read-only audit 2026-06-23.
+Framing: NOT "build a missing page" — `/api/v1/system/license` + an AdminDashboard License panel already
+exist. **The audit's primary finding (§2) reframes the work — read it before §4.**
+
+## 0. DECISION — RATIFIED C+ (owner, 2026-06-23)
+
+This doc stays as the **decision record**. Ratified outcome:
+- Keep this gap audit; **correct the misleading `docs/FEATURE_LICENSING.md`** (it claimed enforcement is wired — see §2.4) to a "placeholder / not enforced yet" status.
+- Do **NOT** polish the License admin UI, remove the dead methods, or start real licensing — the subsystem enforces nothing (§2), so polish has near-zero value.
+- **Next mainline = Sensitive-Data Logging Audit Phase 1** (genuinely live + high-value).
+- Minimal honest loop = a **doc-only PR** (this gap audit + the `FEATURE_LICENSING.md` correction); after merge, open the logging-audit taskbook. (= §4 path "(C)" plus the existing-doc fix in §2.4.)
+
+## 1. What exists today (precise, code-grounded)
+
+- Backend `LicenseService` + `LicenseController` (`GET /api/v1/system/license`, `hasRole('ADMIN')`).
+  `LicenseInfo` = `edition, maxUsers:int, maxStorageGb:long, expirationDate:Date?, features:String[], valid:boolean`.
+- Frontend `AdminDashboard.tsx` License panel (L3503-3550): renders the fields as chips; `LicenseInfo` TS type (L147) matches the backend; fetch `.catch(()=>null)` → "Unavailable".
+- Tests: only `LicenseControllerSecurityTest` (security). No shape/contract test.
+
+## 2. ⚠️ PRIMARY FINDING — the license subsystem is a non-enforcing, mock, display-only placeholder
+
+Three code-confirmed facts:
+
+1. **Validation is mocked.** `validateLicense()` (L56-84) is explicitly "MVP/Demo… Placeholder logic":
+   any non-blank/non-`"invalid"` key → **hardcoded Enterprise** (100 users / 1000 GB / +1yr / [WORKFLOW,OCR,AUDIT]);
+   empty → Community; `"invalid"` → Community fallback. No JWT/RSA parsing (imports present, unused).
+   **`valid` is always `true`** on every path — the Valid/Invalid chip is decorative.
+2. **Enforcement is DEAD CODE.** Both enforcement methods have **ZERO callers in the whole repo**:
+   - `isFeatureEnabled(feature)` — defined (L89), never called → **no feature is license-gated**;
+   - `checkUserLimit()` — defined (L104), never called → **the `maxUsers` limit enforces nothing**.
+3. **Single display-only consumer.** `LicenseService` is injected only by `LicenseController` (returns the DTO);
+   `/system/license` is consumed only by `AdminDashboard.tsx` (read-only). No feature enum/registry — feature
+   names are bare string literals inside `LicenseService`.
+4. **An existing doc actively MISCLAIMS enforcement (the most harmful artifact).** `docs/FEATURE_LICENSING.md`
+   (2025-12-10, status "✅ 已完成") stated `checkUserLimit()` "is called on user creation" and `isFeatureEnabled()`
+   "is used in code for feature toggles" — both false (dead code, fact 2). A doc claiming working enforcement is
+   worse than no doc — it misleads the next developer. **Corrected in this PR** to "placeholder / not enforced yet".
+
+→ **The license subsystem enforces nothing. It is mock data rendered in one admin panel.** That is the
+deliverable of this audit: before any admin polish, know that nothing is actually licensed or limited.
+
+## 3. The 5 review points — re-scored against §2
+
+| # | Point | Value GIVEN the placeholder finding |
+|---|---|---|
+| 1 | Expiry severity | near-zero — adds severity to a hardcoded `+1yr` date |
+| 2 | Usage vs limit | near-zero — renders e.g. "3 / 5" against a limit that enforces nothing |
+| 3 | Feature display vs `isFeatureEnabled` | **cosmetic** — `isFeatureEnabled` is dead, so there is no *functional* inconsistency, just two unused representations |
+| 4 | Shape test | low — pins a display-only contract |
+| 5 | Docs (editions / invalid / status) | **HIGH — and worse than "none":** `FEATURE_LICENSING.md` exists and *misclaims* enforcement (§2.4); correcting it to "placeholder / not enforced" is the P1 doc action (done in this PR) |
+
+## 4. Recommendation — the audit changes the call: do NOT default to a polish loop
+
+Polishing #1-#4 decorates a façade that enforces nothing. Three honest directions:
+
+- **(A) Document + dead-code hygiene (small, closeable).** Correct the license-status doc (`FEATURE_LICENSING.md`,
+  done in this PR); and either mark/remove the two dead methods OR add a "not enforced yet" note to the admin
+  panel so the UI doesn't imply enforcement. ~0.5 day. (This PR took the doc-correction half only — see §0.)
+- **(B) Make licensing REAL (separate, deliberate product line — NOT a small loop).** Real key verification
+  (JWT/RSA) + WIRE `checkUserLimit`/`isFeatureEnabled` into the create-user / feature paths + a feature registry.
+  Only if licensing is a genuine product requirement. This is a product-semantic decision, not a starter loop.
+- **(C) Document (A's doc) + move the small-loop starter to the next candidate.** Take the **Sensitive-Data
+  Logging Audit (your #2 priority)** — which is genuinely *live* and high-value — as the first small loop instead.
+
+**My lean: (C).** The gap audit did its job — it found the License Admin "enhancement" would polish a
+placeholder. The honest move is a short status doc (A's doc), then start the real small loop on the logging
+audit. "Make licensing real" (B) is a separate product decision to schedule on its own, not bootstrap here.
+
+## 5. Next step (C+ ratified — see §0)
+
+After this doc-only PR merges: open the **Sensitive-Data Logging Audit Phase 1** taskbook (read-only
+classification) as the new small-loop starter. **Real licensing remains a separate product decision** (§4 (B)),
+not bootstrapped here.


### PR DESCRIPTION
## Summary
Doc-only. A read-only gap audit of the License/Entitlement admin surface found the license subsystem is a **non-enforcing placeholder**, and an existing doc actively misclaimed otherwise.

## Findings (code-confirmed, 2026-06-23)
- `validateLicense()` is a mock — any non-blank, non-`invalid` key → hardcoded Enterprise; `valid` is always `true` (no JWT/RSA verification).
- `checkUserLimit()` and `isFeatureEnabled()` have **zero callers** (dead code) — no user limit or feature is actually enforced.
- `/system/license` is a single read-only admin display (`AdminDashboard.tsx`).
- **`docs/FEATURE_LICENSING.md` (2025-12-10) claimed enforcement was wired** (`checkUserLimit` called on user creation, `isFeatureEnabled` used for feature toggles) — false. A doc claiming working enforcement is worse than no doc.

## Changes (docs only)
- **New** `docs/GAP_AUDIT_LICENSE_ENTITLEMENT_ADMIN_20260623.md` — the gap audit + ratified decision record.
- **Corrected** `docs/FEATURE_LICENSING.md` — status → "placeholder / not enforced yet"; enforcement marked dead-code; validation marked mock; added a "wire enforcement" follow-up.

## Decision (owner, C+)
Keep the gap audit as the record; correct the misleading doc; do NOT polish the License admin UI, remove dead methods, or start real licensing. Next mainline = Sensitive-Data Logging Audit Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)