### PR TITLE
fix(security): sanitize remote transfer HTTP errors (Phase 2 slice 1, finding :376)

### DIFF
--- a/ecm-core/src/main/java/com/ecm/core/service/transfer/AthenaTransferHttpClient.java
+++ b/ecm-core/src/main/java/com/ecm/core/service/transfer/AthenaTransferHttpClient.java
@@ -15,6 +15,7 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -49,11 +50,11 @@ public class AthenaTransferHttpClient implements TransferClient {
             .fromHttpUrl(apiUrl(target, "/transfer/receiver/verify"))
             .queryParam("folderId", target.getTargetFolderId())
             .toUriString();
-        ResponseEntity<JsonNode> response = restTemplate.exchange(
+        ResponseEntity<JsonNode> response = exchangeJson(
             url,
             HttpMethod.GET,
             new HttpEntity<>(jsonHeaders(target)),
-            JsonNode.class
+            "receiver verify"
         );
         JsonNode body = response.getBody();
         if (body == null) {
@@ -191,11 +192,11 @@ public class AthenaTransferHttpClient implements TransferClient {
         request.put("sourceLastModifiedAt", folder.getLastModifiedDate());
 
         HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request, jsonHeaders(target));
-        ResponseEntity<JsonNode> response = restTemplate.exchange(
+        ResponseEntity<JsonNode> response = exchangeJson(
             apiUrl(target, "/transfer/receiver/folders"),
             HttpMethod.POST,
             entity,
-            JsonNode.class
+            "folder replication"
         );
         JsonNode body = response.getBody();
         return new TransferReceiverFolderResult(
@@ -247,11 +248,11 @@ public class AthenaTransferHttpClient implements TransferClient {
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
 
-        ResponseEntity<JsonNode> response = restTemplate.exchange(
+        ResponseEntity<JsonNode> response = exchangeJson(
             apiUrl(target, "/transfer/receiver/documents"),
             HttpMethod.POST,
             new HttpEntity<>(body, headers),
-            JsonNode.class
+            "document upload"
         );
         JsonNode bodyNode = response.getBody();
         return new TransferReceiverDocumentResult(
@@ -308,6 +309,43 @@ public class AthenaTransferHttpClient implements TransferClient {
             throw new IllegalArgumentException(message);
         }
         return value;
+    }
+
+    /**
+     * Phase 2 logging-audit fix (gate finding 2026-06-23, confirmed at
+     * {@code TransferReplicationService:376}). Spring's
+     * {@link RestClientResponseException} (HttpClientErrorException /
+     * HttpServerErrorException) embeds the remote response body verbatim in
+     * {@code getMessage()} / {@code toString()}. A failed replication propagates
+     * that exception out to {@code TransferReplicationService}, which logs
+     * {@code ex.getMessage()} at WARN and persists it to {@code transportMessage} /
+     * {@code errorLog} / the failure entry report — leaking the remote body to logs
+     * AND the database. We sanitize at the transfer-client boundary (NOT via a global
+     * RestTemplate error handler, so the shared RestTemplate used by WOPI / preview /
+     * ML, etc. is unaffected): rethrow a status-only exception that keeps the operation
+     * and HTTP status for triage but never the body. {@code ResourceAccessException}
+     * (no response received, no body) is intentionally NOT caught and propagates as-is.
+     * Mirrors {@code OAuthCredentialService.sanitizedHttpCause}.
+     */
+    private ResponseEntity<JsonNode> exchangeJson(String url, HttpMethod method, HttpEntity<?> entity, String operation) {
+        try {
+            return restTemplate.exchange(url, method, entity, JsonNode.class);
+        } catch (RestClientResponseException ex) {
+            throw sanitizedTransferHttpError(ex, operation);
+        }
+    }
+
+    private static RuntimeException sanitizedTransferHttpError(RestClientResponseException ex, String operation) {
+        // Sanitized stand-in cause: exception class + HTTP status only, original stack copied
+        // for debuggability — the response body never reaches getMessage()/printStackTrace().
+        RuntimeException sanitizedCause = new RuntimeException(
+            ex.getClass().getSimpleName() + " (HTTP " + ex.getStatusCode().value() + ")"
+        );
+        sanitizedCause.setStackTrace(ex.getStackTrace());
+        return new IllegalStateException(
+            "Remote transfer " + operation + " failed: HTTP " + ex.getStatusCode().value(),
+            sanitizedCause
+        );
     }
 
     private byte[] readContent(Document document) {

--- a/ecm-core/src/test/java/com/ecm/core/service/transfer/AthenaTransferHttpClientTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/service/transfer/AthenaTransferHttpClientTest.java
@@ -25,6 +25,10 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.mockito.Mockito.when;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
@@ -186,6 +190,32 @@ class AthenaTransferHttpClientTest {
         assertEquals(3, result.entries().size());
         assertEquals("UNCHANGED", result.entries().get(1).action());
         assertEquals(remoteDocId, result.entries().get(2).targetNodeId());
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("Phase 2 slice 1 (finding :376): a remote HTTP error is sanitized — the response body never reaches the thrown exception message or its stack trace, but the HTTP status + operation are preserved")
+    void remoteHttpErrorBodyIsSanitized() {
+        TransferTarget target = remoteTarget();
+        String sensitiveBody = "{\"error\":\"BODY-LEAK-MARKER-zzz\",\"detail\":\"do-not-log-this\"}";
+        server.expect(requestTo("https://remote.example/api/v1/transfer/receiver/verify?folderId=" + target.getTargetFolderId()))
+            .andRespond(withServerError().body(sensitiveBody).contentType(MediaType.APPLICATION_JSON));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> client.verifyTarget(target));
+
+        // status + operation preserved for triage; body NOT in the message
+        assertThat(ex.getMessage(), containsString("HTTP 500"));
+        assertThat(ex.getMessage(), containsString("receiver verify"));
+        assertThat(ex.getMessage(), not(containsString("BODY-LEAK-MARKER")));
+
+        // banked lesson: SLF4J emits the whole cause chain via printStackTrace — assert the
+        // body is absent from the FULL stack-trace string, not just getMessage().
+        java.io.StringWriter sw = new java.io.StringWriter();
+        ex.printStackTrace(new java.io.PrintWriter(sw));
+        String trace = sw.toString();
+        assertThat(trace, not(containsString("BODY-LEAK-MARKER")));
+        assertThat(trace, not(containsString("do-not-log-this")));
+
         server.verify();
     }
 


### PR DESCRIPTION
## Summary
Phase 2 Slice 1 of the sensitive-data logging audit. Fixes the **confirmed** finding `TransferReplicationService:376`: a failed transfer to a remote receiver leaked the remote HTTP **response body** into the WARN log AND the DB (`transportMessage` / `errorLog` / failure report).

## Root cause (Phase 1 findings, PR #28)
`AthenaTransferHttpClient` uses the default `RestTemplate` (`config/RestTemplateConfig.java:12`, no `ResponseErrorHandler`) and does not catch its `exchange()` calls. On 4xx/5xx the default handler throws a raw `HttpClientErrorException`, whose `getMessage()` embeds the response-body excerpt, which propagates to `TransferReplicationService:376` (`log.warn(... ex.getMessage())`) and is persisted to `job.transportMessage` (:389) + the failure entry report (:384).

## Fix
At the **transfer-client boundary** (NOT a global RestTemplate handler — the shared `RestTemplate` used by WOPI / preview / ML stays unaffected): the three `exchange()` calls go through a new `exchangeJson()` that catches `RestClientResponseException` and rethrows a **status-only** `IllegalStateException` (operation + HTTP status; a sanitized stand-in cause with the original stack copied; **no body**). Mirrors the existing `OAuthCredentialService.sanitizedHttpCause`. `ResourceAccessException` (no response, no body) is intentionally left to propagate.

Fix targets (all met — body absent, status/operation kept): log, `transportMessage`, `errorLog`, failure entry report.

## Test
`AthenaTransferHttpClientTest.remoteHttpErrorBodyIsSanitized`: a 500 + sensitive body yields a thrown exception whose **message AND full `printStackTrace`** carry `HTTP 500` + the operation but NOT the body marker.

Follows the doc-only findings PR #28. Slice 2 (TOTP) + the mail full-throwable track follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)