### PR TITLE
fix(security): log TOTP HMAC-failure exception type only (Phase 2 slice 2, finding :82)

### DIFF
--- a/ecm-core/src/main/java/com/ecm/core/security/mfa/TotpService.java
+++ b/ecm-core/src/main/java/com/ecm/core/security/mfa/TotpService.java
@@ -79,7 +79,10 @@ public class TotpService {
             mac.init(new SecretKeySpec(key, HMAC_ALGORITHM));
             return mac.doFinal(data);
         } catch (Exception e) {
-            log.error("Failed to compute HMAC", e);
+            // Phase 2 logging audit slice 2 (finding :82): log the exception TYPE only, not the
+            // Throwable — a crypto/key path; passing `e` would let SLF4J walk its cause chain
+            // (and any JCA message) into the log sink. Mirrors MailAutomationController:362.
+            log.error("Failed to compute HMAC: type={}", e.getClass().getSimpleName());
             throw new IllegalStateException("Unable to generate TOTP code", e);
         }
     }

--- a/ecm-core/src/test/java/com/ecm/core/security/mfa/TotpServiceHmacFailureLoggingTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/security/mfa/TotpServiceHmacFailureLoggingTest.java
@@ -1,0 +1,69 @@
+package com.ecm.core.security.mfa;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Phase 2 logging audit slice 2 (finding {@code TotpService:82}). Locks the runtime log shape of the
+ * HMAC-failure catch block: the production change replaces {@code log.error("Failed to compute HMAC", e)}
+ * (full {@link Throwable} -&gt; SLF4J emits its stack and cause-chain messages — a crypto/key path) with
+ * {@code log.error("Failed to compute HMAC: type={}", e.getClass().getSimpleName())} so no exception
+ * message or stack can carry key material into the log sink. Mirrors
+ * {@code MailAutomationControllerOAuthCallbackLoggingTest}.
+ */
+class TotpServiceHmacFailureLoggingTest {
+
+    private Logger logger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void setUp() {
+        logger = (Logger) LoggerFactory.getLogger(TotpService.class);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+    }
+
+    @Test
+    @DisplayName("HMAC failure logs the exception TYPE only — no Throwable attached, so no cause chain / key material reaches the log")
+    void hmacFailureLogsTypeWithoutThrowable() throws Exception {
+        TotpService service = new TotpService();
+        Method generateCode = TotpService.class.getDeclaredMethod("generateCode", String.class, long.class);
+        generateCode.setAccessible(true);
+
+        // Empty secret -> empty key -> SecretKeySpec rejects it -> the HMAC catch block (:81-84) fires.
+        InvocationTargetException ite = assertThrows(InvocationTargetException.class,
+            () -> generateCode.invoke(service, "", 1L));
+        assertNotNull(ite.getCause(), "the HMAC failure should surface as a thrown cause");
+
+        ILoggingEvent event = appender.list.stream()
+            .filter(e -> e.getFormattedMessage().contains("Failed to compute HMAC"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("expected an HMAC-failure log event"));
+
+        // The Throwable is NOT attached -> SLF4J cannot walk its cause chain into the log sink.
+        assertNull(event.getThrowableProxy(), "HMAC-failure log must not carry the Throwable");
+        // The exception type is preserved for triage.
+        assertThat(event.getFormattedMessage(), containsString("type="));
+    }
+}


### PR DESCRIPTION
## Summary
Phase 2 Slice 2 of the sensitive-data logging audit. Fixes finding `TotpService:82`: the HMAC-failure catch logged the **full Throwable** in a crypto/key path.

## Change
`log.error("Failed to compute HMAC", e)` -> `log.error("Failed to compute HMAC: type={}", e.getClass().getSimpleName())` — the exception **type** is kept for triage; the Throwable (stack + cause-chain messages) is no longer emitted, so a JCA exception carrying key/format detail can't reach the log sink. Mirrors `MailAutomationController:362`.

The rethrow at `:83` (`new IllegalStateException("Unable to generate TOTP code", e)`) is unchanged — JCA exceptions (NoSuchAlgorithmException / InvalidKeyException / "Empty key") are not body/key-bearing like the HTTP case; out of this slice's scope.

## Test
`TotpServiceHmacFailureLoggingTest` captures the logger via a `ListAppender`, triggers the HMAC failure (empty key -> empty SecretKeySpec), and asserts the log event keeps the exception type but has **no attached Throwable**.

Follows slice 1 (#29, merged). The mail full-throwable track follows separately (positive-proof first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)