### PR TITLE
docs(security): close out sensitive logging audit

### DIFF
--- a/docs/DEV_AND_VERIFICATION_SENSITIVE_DATA_LOGGING_AUDIT_20260624.md
+++ b/docs/DEV_AND_VERIFICATION_SENSITIVE_DATA_LOGGING_AUDIT_20260624.md
@@ -1,0 +1,164 @@
+# Sensitive-Data Logging Audit - Development and Verification Closeout
+
+Date: 2026-06-24
+Repository: Athena
+Status: Complete for the ratified high-risk audit/remediation line. Remaining low/medium `NEEDS-MASK`
+sites are documented backlog, not part of this completed slice.
+
+## Objective
+
+The one-week development lane started by checking whether the license/entitlement admin surface was the
+right next small build. The code audit showed the current license subsystem is a non-enforcing placeholder,
+so that work was closed as honest documentation instead of UI polish. The main build lane then moved to
+the previously identified sensitive-data logging audit.
+
+This closeout records:
+
+- the license/entitlement status correction that prevented building on a mock subsystem;
+- the Phase 1 sensitive-data logging findings;
+- the Phase 2 remediation slices for the highest-risk sinks;
+- the verification evidence used to close the lane.
+
+## Delivered Work
+
+| PR | Commit | Scope | Result |
+|---|---|---|---|
+| #27 | `69bcd7a` | License/entitlement gap audit and `FEATURE_LICENSING.md` correction | Merged. Licensing is documented as placeholder/non-enforcing. |
+| #28 | `a110e4d` | Sensitive-data logging Phase 1 taskbook and findings | Merged. Phase 2 gate opened by high-risk `NEEDS-MASK` sites. |
+| #29 | `2cc107f` | Transfer replication HTTP error sanitization | Merged. Remote response body no longer reaches transfer logs or persisted job failure fields. |
+| #30 | `6a406ef` | TOTP HMAC failure logging | Merged. Crypto-path HMAC failure logs exception type only, no attached throwable. |
+| #31 | `7866fc5` | Mail high-risk error sinks | Merged. Five full-throwable mail log sites and three same-source persisted error sinks now use type/code-only output. |
+
+This branch adds the closeout polish:
+
+- aligns the `MailFetcherServiceLoggingRedactionTest` simulated message-processing log with the current
+  production type-only format;
+- adds a real account-processing failure test for `MailFetcherService` `:184/:185`, proving both the log
+  and `lastFetchError` store exception type only;
+- records this development and verification closeout.
+
+## Phase 1 Findings Summary
+
+Source: `docs/SENSITIVE_DATA_LOGGING_AUDIT_FINDINGS_20260623.md`.
+
+Important audit rules:
+
+- `log.X(..., throwable)` was evaluated against the full throwable/cause chain, not just the top-level
+  message.
+- A single high-risk `NEEDS-MASK` site could open Phase 2 even without a named secret leak.
+- `System.out` and `System.err` were checked for the in-scope sensitive lanes.
+
+Phase 1 result:
+
+- `LEAKS`: 0
+- `System.out`/`System.err`: 0 in scope
+- `NEEDS-MASK`: about 38, including about 8 high-risk sites
+- Phase 2 gate: met
+
+The strongest confirmed finding was `TransferReplicationService:376`: default `RestTemplate` HTTP errors
+could carry a remote response-body excerpt into the WARN log and persisted transfer failure fields.
+
+## Remediation Summary
+
+### Slice 1 - Transfer HTTP Errors
+
+Files:
+
+- `ecm-core/src/main/java/com/ecm/core/service/transfer/AthenaTransferHttpClient.java`
+- `ecm-core/src/test/java/com/ecm/core/service/transfer/AthenaTransferHttpClientTest.java`
+
+Behavior:
+
+- catches remote transfer HTTP errors at the client boundary;
+- converts them to status-only failure text;
+- prevents response body excerpts from reaching logs, `transportMessage`, `errorLog`, or entry reports.
+
+### Slice 2 - TOTP HMAC Failure
+
+Files:
+
+- `ecm-core/src/main/java/com/ecm/core/security/mfa/TotpService.java`
+- `ecm-core/src/test/java/com/ecm/core/security/mfa/TotpServiceHmacFailureLoggingTest.java`
+
+Behavior:
+
+- replaces full throwable logging with exception type-only logging;
+- keeps the thrown application exception behavior unchanged;
+- locks the log shape with a `ListAppender` assertion that no `ThrowableProxy` is attached.
+
+### Slice 3 - Mail Error Sinks
+
+Files:
+
+- `ecm-core/src/main/java/com/ecm/core/integration/mail/service/MailFetcherService.java`
+- `ecm-core/src/main/java/com/ecm/core/integration/mail/service/MailReportScheduledExportService.java`
+- `ecm-core/src/test/java/com/ecm/core/integration/mail/service/MailFetcherServiceLoggingRedactionTest.java`
+- `ecm-core/src/test/java/com/ecm/core/integration/mail/service/MailReportScheduledExportServiceTest.java`
+
+Behavior:
+
+- converts high-risk mail full-throwable logs to type-only output:
+  - account processing failure;
+  - message processing failure;
+  - mail document property update failure;
+  - fetch-status persistence failure;
+  - scheduled report export failure;
+- converts adjacent persisted/admin-visible error sinks to code/type-only:
+  - OAuth reauth `lastFetchError` stores OAuth code only;
+  - generic account failure `lastFetchError` stores exception type only;
+  - scheduled export failure result stores exception type only.
+
+Positive-proof result before remediation: none of the five mail log sites was promoted to a confirmed
+content leak, but none was provably safe while emitting a full throwable. Type-only remediation was the
+smallest consistent fix.
+
+## Verification Evidence
+
+GitHub checks:
+
+- #28: 7/7 checks passed before merge.
+- #29: 7/7 checks passed before merge.
+- #30: 7/7 checks passed before merge.
+- #31: 7/7 checks passed before merge.
+
+Local targeted verification command:
+
+```bash
+cd ecm-core
+./mvnw -q -Dtest=AthenaTransferHttpClientTest,TotpServiceHmacFailureLoggingTest,MailFetcherServiceLoggingRedactionTest,MailReportScheduledExportServiceTest test
+```
+
+Result before this closeout patch: passed. It also exposed a stale simulated test log shape for the
+message-processing mail site; this branch corrects that test to match the current type-only production
+format and adds the missing account-processing failure proof.
+
+Expected proof after this closeout patch:
+
+- transfer HTTP response body fragments do not reach transfer failure messages;
+- TOTP HMAC failure log has no attached throwable;
+- mail message-processing log has no attached throwable and no raw subject/cause message;
+- mail account-processing failure log has no attached throwable and no provider/cause message;
+- mail generic account failure stores `RuntimeException` instead of `e.getMessage()`;
+- mail OAuth reauth failure stores the OAuth error code, not provider `errorDescription`;
+- mail scheduled export failure stores/logs exception type only.
+
+## Remaining Backlog
+
+The following are intentionally not part of this closed high-risk line:
+
+- lower-priority mail `e.getMessage()` `WARN`/`DEBUG` sites from the Phase 1 findings;
+- broader PII policy decisions for subject, sender, recipient, and message-content diagnostics;
+- library/framework logging controls outside `com.ecm.*`;
+- turning the placeholder license subsystem into real license enforcement.
+
+These should be scheduled only if product/security policy requires them. They are not blockers for this
+completed sensitive-data logging audit high-risk track.
+
+## Closeout Decision
+
+The selected one-week lane is complete once this closeout patch passes the targeted backend tests:
+
+- the mock license-admin idea was corrected into documentation rather than misleading UI;
+- the sensitive-data logging Phase 1 audit is stored in docs;
+- every ratified high-risk remediation slice is merged on `main`;
+- the remaining lower-risk `NEEDS-MASK` population is explicitly documented as backlog.

--- a/ecm-core/src/test/java/com/ecm/core/integration/mail/service/MailFetcherServiceLoggingRedactionTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/integration/mail/service/MailFetcherServiceLoggingRedactionTest.java
@@ -16,18 +16,23 @@ import com.ecm.core.service.NodeService;
 import com.ecm.core.service.TagService;
 import com.ecm.core.service.TenantContextResolverService;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -38,20 +43,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Phase 2 logging audit (2026-05-23) — locks the two helper-method semantics
+ * Phase 2 logging audit (2026-05-23) - locks the two helper-method semantics
  * and the runtime log emission format used by:
  *
  * <ul>
- *   <li>{@code MailFetcherService:786} — "Error processing message" log</li>
- *   <li>{@code MailFetcherService:164} — "OAuth reauth required" log</li>
+ *   <li>{@code MailFetcherService} message-processing catch - "Error processing message" log</li>
+ *   <li>{@code MailFetcherService} account-processing catch - "Failed to process mail account" log</li>
+ *   <li>{@code MailFetcherService} OAuth reauth catch - "OAuth reauth required" log</li>
  * </ul>
  *
  * <p>The helpers {@code subjectOrEmpty} and {@code redactSubjectForLog} are
  * package-private by design; this test sits in the same package and exercises
- * them directly. The two {@link ListAppender}-based tests drive the exact
+ * them directly. The {@link ListAppender}-based tests drive the exact
  * log call pattern used at the production call sites against the
  * {@link MailFetcherService} logger, so the format string itself is locked.
  */
@@ -67,7 +74,7 @@ class MailFetcherServiceLoggingRedactionTest {
     @Mock private NodeService nodeService;
     @Mock private TagService tagService;
     @Mock private EmailIngestionService emailIngestionService;
-    @Mock private MeterRegistry meterRegistry;
+    private MeterRegistry meterRegistry;
     @Mock private MailOAuthService mailOAuthService;
     @Mock private TenantContextResolverService tenantContextResolverService;
 
@@ -77,6 +84,7 @@ class MailFetcherServiceLoggingRedactionTest {
 
     @BeforeEach
     void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
         service = new MailFetcherService(
             accountRepository,
             ruleRepository,
@@ -100,6 +108,12 @@ class MailFetcherServiceLoggingRedactionTest {
     @AfterEach
     void tearDown() {
         fetcherLogger.detachAppender(appender);
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterAll
+    static void tearDownAll() {
+        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -137,12 +151,11 @@ class MailFetcherServiceLoggingRedactionTest {
 
     @Test
     @DisplayName(
-        "Simulated :786 log emission via the MailFetcherService logger contains the "
-            + "redaction placeholder and never the raw subject"
+        "Simulated message-processing log emission contains the redaction placeholder, the exception type, and no Throwable"
     )
-    void errorProcessingMessageLogContainsRedactionMarkerNotSubject() throws MessagingException {
+    void errorProcessingMessageLogContainsRedactionMarkerAndTypeOnly() throws MessagingException {
         // Stub the subject with `lenient()` so the test catches a regression where
-        // the production :800 call site is reverted from redactSubjectForLog(message)
+        // the production message-processing log is reverted from redactSubjectForLog(message)
         // back to subjectOrEmpty(message): subjectOrEmpty would then call getSubject()
         // and the stub would supply `sensitive`, which would then leak into the log,
         // failing the assertFalse(contains(sensitive)) below. The current code path
@@ -151,15 +164,16 @@ class MailFetcherServiceLoggingRedactionTest {
         Message message = mock(Message.class);
         String sensitive = "Confidential Q4 layoff plan";
         lenient().when(message.getSubject()).thenReturn(sensitive);
-        RuntimeException cause = new RuntimeException("processing failure");
+        RuntimeException cause = new RuntimeException("processing failure BODY-LEAK-zzz");
 
-        // Drive the exact :786 format string against the production MailFetcherService
-        // logger, with the redacted helper output. Any future regression to safeSubject
-        // / subjectOrEmpty at the :786 call site would emit `sensitive` here.
+        // Drive the current production type-only format string against the
+        // MailFetcherService logger, with the redacted helper output. Any future
+        // regression to subjectOrEmpty would emit `sensitive`; any regression to
+        // `log.error(..., cause)` would attach a ThrowableProxy.
         fetcherLogger.error(
-            "Error processing message: {}",
+            "Error processing message {}: type={}",
             service.redactSubjectForLog(message),
-            cause
+            cause.getClass().getSimpleName()
         );
 
         assertEquals(1, appender.list.size(), "exactly one log event expected");
@@ -169,10 +183,58 @@ class MailFetcherServiceLoggingRedactionTest {
         String formatted = event.getFormattedMessage();
         assertTrue(formatted.contains("<redacted-subject>"),
             "log must include the redaction placeholder; got: " + formatted);
+        assertTrue(formatted.contains("type=RuntimeException"),
+            "log must include the exception type for triage; got: " + formatted);
+        assertNull(event.getThrowableProxy(), "message-processing log must not carry the Throwable");
+        assertFalse(formatted.contains("BODY-LEAK-zzz"),
+            "log must NOT include the cause message; got: " + formatted);
         assertFalse(formatted.contains(sensitive),
             "log must NOT include the raw subject; got: " + formatted);
         assertFalse(formatted.contains("layoff"),
             "log must NOT include any subject substring; got: " + formatted);
+    }
+
+    @Test
+    @DisplayName(
+        "Phase 2 mail slice (:184/:185): account-processing failures log and persist the exception TYPE only"
+    )
+    void accountProcessingFailureLogsAndPersistsTypeOnly() {
+        MailAccount account = new MailAccount();
+        UUID accountId = UUID.fromString("22222222-3333-4444-5555-666666666666");
+        account.setId(accountId);
+        account.setName("primary-oauth");
+        account.setHost("imap.example.test");
+        account.setPort(993);
+        account.setUsername("user@example.com");
+        account.setSecurity(MailAccount.SecurityType.OAUTH2);
+        account.setOauthRefreshToken("present-refresh-token");
+        String sensitive = "provider said user@example.com token=SECRET-zzz scope=mail.read";
+
+        when(accountRepository.findByEnabledTrue()).thenReturn(List.of(account));
+        when(mailOAuthService.checkOAuthEnv(account)).thenReturn(new MailFetcherService.OAuthEnvCheckResult(
+            true,
+            true,
+            null,
+            List.of()
+        ));
+        when(mailOAuthService.resolveAccessToken(account)).thenThrow(new RuntimeException(sensitive));
+        when(accountRepository.save(any(MailAccount.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.fetchAllAccounts(true);
+
+        ILoggingEvent event = appender.list.stream()
+            .filter(e -> e.getFormattedMessage().contains("Failed to process mail account"))
+            .findFirst().orElseThrow(() -> new AssertionError("expected the :184 account-processing log event"));
+        assertNull(event.getThrowableProxy(), ":184 log must not carry the Throwable");
+        assertTrue(event.getFormattedMessage().contains("type=RuntimeException"),
+            "log keeps the exception type for triage");
+        assertFalse(event.getFormattedMessage().contains("SECRET-zzz"), "log must not carry provider details");
+        assertFalse(event.getFormattedMessage().contains("scope=mail.read"), "log must not carry provider details");
+
+        ArgumentCaptor<MailAccount> saved = ArgumentCaptor.forClass(MailAccount.class);
+        verify(accountRepository).save(saved.capture());
+        assertEquals("ERROR", saved.getValue().getLastFetchStatus());
+        assertEquals("RuntimeException", saved.getValue().getLastFetchError());
     }
 
     @Test
@@ -224,7 +286,7 @@ class MailFetcherServiceLoggingRedactionTest {
     @Test
     @DisplayName(
         "Phase 2 mail slice (:179 sink): the OAuth-reauth lastFetchError value is derived from the "
-            + "OAuth CODE, never e.getMessage() — so the provider errorDescription (PII) is not persisted to the admin-UI field"
+            + "OAuth CODE, never e.getMessage() - so the provider errorDescription (PII) is not persisted to the admin-UI field"
     )
     void oauthReauthLastFetchErrorSinkStoresCodeNotDescription() {
         UUID accountId = UUID.fromString("11111111-2222-3333-4444-555555555555");
@@ -246,7 +308,7 @@ class MailFetcherServiceLoggingRedactionTest {
     }
 
     @Test
-    @DisplayName("Phase 2 mail slice (:3096): a failed fetch-status save logs the exception TYPE only — no Throwable, no cause message")
+    @DisplayName("Phase 2 mail slice (:3096): a failed fetch-status save logs the exception TYPE only - no Throwable, no cause message")
     void updateAccountFetchStatusFailureLogsTypeNotThrowable() throws Exception {
         MailAccount account = new MailAccount();
         account.setName("primary-imap");
@@ -267,7 +329,7 @@ class MailFetcherServiceLoggingRedactionTest {
     }
 
     @Test
-    @DisplayName("Phase 2 mail slice (:2492): a failed mail-property update logs the exception TYPE only — no Throwable")
+    @DisplayName("Phase 2 mail slice (:2492): a failed mail-property update logs the exception TYPE only - no Throwable")
     void updateMailDocumentPropertiesFailureLogsTypeNotThrowable() throws Exception {
         UUID documentId = UUID.randomUUID();
         String sensitive = "value too long for column SUBJECT: BODY-LEAK-zzz";


### PR DESCRIPTION
Summary
- Adds the development and verification closeout for the one-week license/status + sensitive-data logging audit lane.
- Tightens the MailFetcherService message-processing log test so it matches the current type-only production format and asserts no ThrowableProxy.
- Adds real account-processing failure coverage for the mail :184/:185 log + persisted lastFetchError type-only behavior.

Verification
- ./mvnw -q -Dtest=AthenaTransferHttpClientTest,TotpServiceHmacFailureLoggingTest,MailFetcherServiceLoggingRedactionTest,MailReportScheduledExportServiceTest test

Notes
- Production remediation is already on main via #28, #29, #30, and #31.
- This PR is closeout documentation plus test-shape hardening only.