### PR TITLE
feat(storage): add read-only capacity observability

### DIFF
--- a/docs/DEVELOPMENT_STORAGE_CAPACITY_OBSERVABILITY_TASKBOOK_20260625.md
+++ b/docs/DEVELOPMENT_STORAGE_CAPACITY_OBSERVABILITY_TASKBOOK_20260625.md
@@ -59,7 +59,7 @@ Implication: Day-2 should add one physical capacity card to this dashboard and r
 
 Required wording and implementation model:
 
-- **Physical content-store capacity**: total/used/free bytes of the filesystem backing `ecm.storage.root-path`, after global dedup.
+- **Physical content-store capacity**: total/used/free bytes of the filesystem backing `ecm.storage.root-path`. This is disk/filesystem headroom for the content root, not Athena content-byte accounting.
 - **Tenant logical usage**: sum of per-tenant `storageUsedBytes` from the frozen ADR-002 model.
 
 Forbidden:
@@ -185,7 +185,7 @@ Extend `TenantMetricsDashboardPage`:
 - Fetch `tenantService.getStorageCapacity()` alongside `listTenants()` / `getTenantMetrics`.
 - Rename the current summary card from `Total Storage Used` to `Tenant Logical Usage`.
 - Add a `Physical Content Store` card showing status, used/free/total, and used percent.
-- Add a short caption that the physical card is deduped store capacity while tenant usage is logical quota usage.
+- Add a short caption that the physical card is the disk/filesystem backing the content root — the upload-block signal — while tenant usage is logical quota usage.
 
 No new dashboard. No tenant quota edit UI.
 

--- a/ecm-core/src/main/java/com/ecm/core/controller/StorageAdminController.java
+++ b/ecm-core/src/main/java/com/ecm/core/controller/StorageAdminController.java
@@ -1,0 +1,26 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.dto.StorageCapacityStatusDto;
+import com.ecm.core.service.StorageCapacityService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Storage Admin", description = "Storage capacity and health diagnostics")
+public class StorageAdminController {
+
+    private final StorageCapacityService storageCapacityService;
+
+    @GetMapping({"/api/admin/storage/capacity", "/api/v1/admin/storage/capacity"})
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Get content-store filesystem capacity")
+    public ResponseEntity<StorageCapacityStatusDto> getStorageCapacity() {
+        return ResponseEntity.ok(storageCapacityService.getStatus());
+    }
+}

--- a/ecm-core/src/main/java/com/ecm/core/dto/StorageCapacityStatusDto.java
+++ b/ecm-core/src/main/java/com/ecm/core/dto/StorageCapacityStatusDto.java
@@ -1,0 +1,16 @@
+package com.ecm.core.dto;
+
+public record StorageCapacityStatusDto(
+    String backendType,
+    String status,
+    long totalBytes,
+    long usableBytes,
+    long usedBytes,
+    double usedPercent,
+    int warnPercent,
+    int criticalPercent,
+    long blockedMinFreeBytes,
+    String rootPath,
+    String error
+) {
+}

--- a/ecm-core/src/main/java/com/ecm/core/service/StorageCapacityService.java
+++ b/ecm-core/src/main/java/com/ecm/core/service/StorageCapacityService.java
@@ -1,0 +1,109 @@
+package com.ecm.core.service;
+
+import com.ecm.core.dto.StorageCapacityStatusDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Slf4j
+@Service
+public class StorageCapacityService {
+
+    static final String BACKEND_TYPE_FILESYSTEM = "filesystem";
+
+    private final Path rootPath;
+    private final int warnPercent;
+    private final int criticalPercent;
+    private final long blockedMinFreeBytes;
+
+    public StorageCapacityService(
+        @Value("${ecm.storage.root-path}") String rootPath,
+        @Value("${ecm.storage.capacity.warn-percent:80}") int warnPercent,
+        @Value("${ecm.storage.capacity.critical-percent:95}") int criticalPercent,
+        @Value("${ecm.storage.capacity.blocked-min-free-bytes:104857600}") long blockedMinFreeBytes
+    ) {
+        this.rootPath = Path.of(rootPath).toAbsolutePath().normalize();
+        this.warnPercent = warnPercent;
+        this.criticalPercent = criticalPercent;
+        this.blockedMinFreeBytes = blockedMinFreeBytes;
+    }
+
+    public StorageCapacityStatusDto getStatus() {
+        if (!Files.exists(rootPath)) {
+            return unknown("content_root_missing");
+        }
+
+        try {
+            FileStore fileStore = Files.getFileStore(rootPath);
+            long totalBytes = safeSpace(fileStore.getTotalSpace());
+            long usableBytes = safeSpace(fileStore.getUsableSpace());
+            long usedBytes = Math.max(0L, totalBytes - usableBytes);
+            double usedPercent = totalBytes > 0
+                ? (usedBytes * 100.0d) / totalBytes
+                : 0.0d;
+
+            return new StorageCapacityStatusDto(
+                BACKEND_TYPE_FILESYSTEM,
+                determineStatus(usableBytes, usedPercent),
+                totalBytes,
+                usableBytes,
+                usedBytes,
+                usedPercent,
+                warnPercent,
+                criticalPercent,
+                blockedMinFreeBytes,
+                rootPath.toString(),
+                null
+            );
+        } catch (IOException | RuntimeException ex) {
+            log.debug("Unable to inspect content store capacity for {}", rootPath, ex);
+            return unknown(ex.getClass().getSimpleName());
+        }
+    }
+
+    private StorageCapacityStatusDto unknown(String error) {
+        return new StorageCapacityStatusDto(
+            BACKEND_TYPE_FILESYSTEM,
+            StorageCapacityStatus.UNKNOWN.name(),
+            0L,
+            0L,
+            0L,
+            0.0d,
+            warnPercent,
+            criticalPercent,
+            blockedMinFreeBytes,
+            rootPath.toString(),
+            error
+        );
+    }
+
+    private String determineStatus(long usableBytes, double usedPercent) {
+        if (blockedMinFreeBytes >= 0 && usableBytes <= blockedMinFreeBytes) {
+            return StorageCapacityStatus.BLOCKED.name();
+        }
+        if (usedPercent >= criticalPercent) {
+            return StorageCapacityStatus.CRITICAL.name();
+        }
+        if (usedPercent >= warnPercent) {
+            return StorageCapacityStatus.WARN.name();
+        }
+        return StorageCapacityStatus.OK.name();
+    }
+
+    private long safeSpace(long value) {
+        return Math.max(0L, value);
+    }
+
+    enum StorageCapacityStatus {
+        OK,
+        WARN,
+        CRITICAL,
+        BLOCKED,
+        UNKNOWN
+    }
+}

--- a/ecm-core/src/test/java/com/ecm/core/controller/StorageAdminControllerSecurityTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/StorageAdminControllerSecurityTest.java
@@ -1,0 +1,91 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.dto.StorageCapacityStatusDto;
+import com.ecm.core.service.StorageCapacityService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = StorageAdminController.class)
+@ContextConfiguration(classes = {
+    StorageAdminController.class,
+    RestExceptionHandler.class,
+    StorageAdminControllerSecurityTest.TestSecurityConfig.class
+})
+class StorageAdminControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StorageCapacityService storageCapacityService;
+
+    @Configuration
+    @EnableWebSecurity
+    @EnableMethodSecurity(prePostEnabled = true)
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/api/**").authenticated()
+                    .anyRequest().permitAll()
+                )
+                .httpBasic(basic -> {});
+            return http.build();
+        }
+    }
+
+    @Test
+    @DisplayName("unauthenticated GET /admin/storage/capacity returns 401")
+    void unauthenticatedCapacityReturns401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/storage/capacity"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("ROLE_USER cannot read storage capacity")
+    void userCannotReadCapacity() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/storage/capacity"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("ROLE_ADMIN can read storage capacity")
+    void adminCanReadCapacity() throws Exception {
+        when(storageCapacityService.getStatus()).thenReturn(new StorageCapacityStatusDto(
+            "filesystem",
+            "OK",
+            1000L,
+            900L,
+            100L,
+            10.0d,
+            80,
+            95,
+            104857600L,
+            "/var/ecm/content",
+            null
+        ));
+
+        mockMvc.perform(get("/api/v1/admin/storage/capacity"))
+            .andExpect(status().isOk());
+    }
+}

--- a/ecm-core/src/test/java/com/ecm/core/controller/StorageAdminControllerTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/StorageAdminControllerTest.java
@@ -1,0 +1,65 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.dto.StorageCapacityStatusDto;
+import com.ecm.core.service.StorageCapacityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class StorageAdminControllerTest {
+
+    @Mock
+    private StorageCapacityService storageCapacityService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new StorageAdminController(storageCapacityService))
+            .setControllerAdvice(new RestExceptionHandler())
+            .build();
+    }
+
+    @Test
+    @DisplayName("GET /admin/storage/capacity returns filesystem capacity status")
+    void getStorageCapacityReturnsStatus() throws Exception {
+        when(storageCapacityService.getStatus()).thenReturn(new StorageCapacityStatusDto(
+            "filesystem",
+            "WARN",
+            1000L,
+            150L,
+            850L,
+            85.0d,
+            80,
+            95,
+            104857600L,
+            "/var/ecm/content",
+            null
+        ));
+
+        mockMvc.perform(get("/api/v1/admin/storage/capacity"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.backendType").value("filesystem"))
+            .andExpect(jsonPath("$.status").value("WARN"))
+            .andExpect(jsonPath("$.totalBytes").value(1000))
+            .andExpect(jsonPath("$.usableBytes").value(150))
+            .andExpect(jsonPath("$.usedBytes").value(850))
+            .andExpect(jsonPath("$.usedPercent").value(85.0d))
+            .andExpect(jsonPath("$.warnPercent").value(80))
+            .andExpect(jsonPath("$.criticalPercent").value(95))
+            .andExpect(jsonPath("$.blockedMinFreeBytes").value(104857600))
+            .andExpect(jsonPath("$.rootPath").value("/var/ecm/content"))
+            .andExpect(jsonPath("$.error").doesNotExist());
+    }
+}

--- a/ecm-core/src/test/java/com/ecm/core/service/StorageCapacityServiceTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/service/StorageCapacityServiceTest.java
@@ -1,0 +1,97 @@
+package com.ecm.core.service;
+
+import com.ecm.core.dto.StorageCapacityStatusDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StorageCapacityServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("reports filesystem capacity for an existing content root")
+    void reportsFilesystemCapacity() {
+        StorageCapacityService service = new StorageCapacityService(
+            tempDir.toString(),
+            101,
+            101,
+            -1
+        );
+
+        StorageCapacityStatusDto status = service.getStatus();
+
+        assertThat(status.backendType()).isEqualTo("filesystem");
+        assertThat(status.status()).isEqualTo("OK");
+        assertThat(status.totalBytes()).isGreaterThan(0L);
+        assertThat(status.usableBytes()).isGreaterThan(0L);
+        assertThat(status.usedBytes()).isGreaterThanOrEqualTo(0L);
+        assertThat(status.usedPercent()).isGreaterThanOrEqualTo(0.0d);
+        assertThat(status.rootPath()).isEqualTo(tempDir.toAbsolutePath().normalize().toString());
+        assertThat(status.error()).isNull();
+    }
+
+    @Test
+    @DisplayName("returns UNKNOWN without creating a missing content root")
+    void missingRootIsUnknownAndHasNoWriteSideEffect() {
+        Path missingRoot = tempDir.resolve("missing-content-root");
+        StorageCapacityService service = new StorageCapacityService(
+            missingRoot.toString(),
+            80,
+            95,
+            104857600
+        );
+
+        StorageCapacityStatusDto status = service.getStatus();
+
+        assertThat(status.status()).isEqualTo("UNKNOWN");
+        assertThat(status.error()).isEqualTo("content_root_missing");
+        assertThat(status.totalBytes()).isZero();
+        assertThat(status.usableBytes()).isZero();
+        assertThat(missingRoot).doesNotExist();
+    }
+
+    @Test
+    @DisplayName("applies WARN threshold without changing quota enforcement")
+    void appliesWarnThreshold() {
+        StorageCapacityService service = new StorageCapacityService(
+            tempDir.toString(),
+            0,
+            101,
+            -1
+        );
+
+        assertThat(service.getStatus().status()).isEqualTo("WARN");
+    }
+
+    @Test
+    @DisplayName("applies CRITICAL threshold ahead of WARN")
+    void appliesCriticalThreshold() {
+        StorageCapacityService service = new StorageCapacityService(
+            tempDir.toString(),
+            0,
+            0,
+            -1
+        );
+
+        assertThat(service.getStatus().status()).isEqualTo("CRITICAL");
+    }
+
+    @Test
+    @DisplayName("applies BLOCKED threshold as observability status")
+    void appliesBlockedThreshold() {
+        StorageCapacityService service = new StorageCapacityService(
+            tempDir.toString(),
+            101,
+            101,
+            Long.MAX_VALUE
+        );
+
+        assertThat(service.getStatus().status()).isEqualTo("BLOCKED");
+    }
+}

--- a/ecm-frontend/src/pages/TenantMetricsDashboardPage.test.tsx
+++ b/ecm-frontend/src/pages/TenantMetricsDashboardPage.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { toast } from 'react-toastify';
+import TenantMetricsDashboardPage from './TenantMetricsDashboardPage';
+import tenantService from 'services/tenantService';
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('services/tenantService', () => ({
+  __esModule: true,
+  default: {
+    listTenants: jest.fn(),
+    getTenantMetrics: jest.fn(),
+    getStorageCapacity: jest.fn(),
+  },
+}));
+
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Bar: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  CartesianGrid: () => <div />,
+  Tooltip: () => <div />,
+  Legend: () => <div />,
+  PieChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Pie: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Cell: () => <div />,
+}));
+
+const mockedTenantService = tenantService as jest.Mocked<typeof tenantService>;
+const toastWarnMock = toast.warn as jest.Mock;
+
+const tenants = [
+  {
+    id: 'tenant-1',
+    tenantDomain: 'acme',
+    tenantName: 'Acme',
+    enabled: true,
+    rootNodeId: 'root-acme',
+    quotaBytes: 1000,
+    systemDefault: false,
+    createdDate: '2026-01-01T00:00:00Z',
+    lastModifiedDate: null,
+  },
+  {
+    id: 'tenant-2',
+    tenantDomain: 'beta',
+    tenantName: 'Beta',
+    enabled: true,
+    rootNodeId: 'root-beta',
+    quotaBytes: 2000,
+    systemDefault: false,
+    createdDate: '2026-01-02T00:00:00Z',
+    lastModifiedDate: null,
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedTenantService.listTenants.mockResolvedValue(tenants);
+  mockedTenantService.getTenantMetrics.mockImplementation(async (tenantDomain: string) => {
+    if (tenantDomain === 'acme') {
+      return {
+        tenantDomain: 'acme',
+        tenantName: 'Acme',
+        enabled: true,
+        storageUsedBytes: 1024,
+        quotaBytes: 2048,
+        storageAvailableBytes: 1024,
+        nodeCount: 3,
+        documentCount: 2,
+        folderCount: 1,
+      };
+    }
+
+    return {
+      tenantDomain: 'beta',
+      tenantName: 'Beta',
+      enabled: true,
+      storageUsedBytes: 512,
+      quotaBytes: 2048,
+      storageAvailableBytes: 1536,
+      nodeCount: 4,
+      documentCount: 1,
+      folderCount: 3,
+    };
+  });
+  mockedTenantService.getStorageCapacity.mockResolvedValue({
+    backendType: 'filesystem',
+    status: 'OK',
+    totalBytes: 1024 * 1024,
+    usableBytes: 900 * 1024,
+    usedBytes: 124 * 1024,
+    usedPercent: 12.109,
+    warnPercent: 80,
+    criticalPercent: 95,
+    blockedMinFreeBytes: 104857600,
+    rootPath: '/var/ecm/content',
+    error: null,
+  });
+});
+
+test('renders physical filesystem capacity separately from tenant logical usage', async () => {
+  render(<TenantMetricsDashboardPage />);
+
+  expect(await screen.findByText('Tenant Logical Usage')).toBeTruthy();
+  expect(screen.getByText('1.5 KB')).toBeTruthy();
+  expect(screen.getByText('Content Store Filesystem (Disk)')).toBeTruthy();
+  expect(screen.getByText('900.0 KB free')).toBeTruthy();
+  expect(screen.getByText('OK')).toBeTruthy();
+  expect(screen.getByText('12.1% used of 1.0 MB')).toBeTruthy();
+  expect(screen.getByText('Disk backing content root; upload-block signal, separate from tenant logical quota.')).toBeTruthy();
+
+  await waitFor(() => expect(mockedTenantService.getStorageCapacity).toHaveBeenCalledTimes(1));
+  expect(mockedTenantService.getTenantMetrics).toHaveBeenCalledWith('acme');
+  expect(mockedTenantService.getTenantMetrics).toHaveBeenCalledWith('beta');
+});
+
+test('keeps tenant metrics visible when capacity fetch fails', async () => {
+  mockedTenantService.getStorageCapacity.mockRejectedValueOnce(new Error('capacity unavailable'));
+
+  render(<TenantMetricsDashboardPage />);
+
+  expect(await screen.findByText('Tenant Logical Usage')).toBeTruthy();
+  expect(screen.getByText('1.5 KB')).toBeTruthy();
+  expect(screen.getByText('Content Store Filesystem (Disk)')).toBeTruthy();
+  expect(screen.getByText('Unavailable')).toBeTruthy();
+  expect(screen.getByText('Storage capacity unavailable. Tenant logical metrics are still shown.')).toBeTruthy();
+  expect(toastWarnMock).toHaveBeenCalledWith('Failed to load storage capacity');
+});

--- a/ecm-frontend/src/pages/TenantMetricsDashboardPage.tsx
+++ b/ecm-frontend/src/pages/TenantMetricsDashboardPage.tsx
@@ -27,6 +27,7 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import tenantService, { TenantDto, TenantMetricsDto } from 'services/tenantService';
+import type { StorageCapacityStatusDto } from 'services/tenantService';
 
 const PIE_COLORS = [
   '#1976d2',
@@ -46,6 +47,25 @@ const formatBytes = (bytes: number | null): string => {
   return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
 };
 
+const formatPercent = (value: number | null | undefined): string =>
+  value == null ? '0.0%' : `${value.toFixed(1)}%`;
+
+const getCapacityChipColor = (
+  status?: StorageCapacityStatusDto['status'],
+): 'default' | 'success' | 'warning' | 'error' => {
+  switch (status) {
+    case 'OK':
+      return 'success';
+    case 'WARN':
+      return 'warning';
+    case 'CRITICAL':
+    case 'BLOCKED':
+      return 'error';
+    default:
+      return 'default';
+  }
+};
+
 interface StorageBarDatum {
   tenantName: string;
   storageUsed: number;
@@ -63,10 +83,18 @@ const TenantMetricsDashboardPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [metrics, setMetrics] = useState<TenantMetricsDto[]>([]);
   const [failedDomains, setFailedDomains] = useState<string[]>([]);
+  const [storageCapacity, setStorageCapacity] = useState<StorageCapacityStatusDto | null>(null);
+  const [capacityFailed, setCapacityFailed] = useState(false);
 
   const loadData = useCallback(async () => {
     setLoading(true);
     setFailedDomains([]);
+    setCapacityFailed(false);
+
+    const capacityResult = tenantService.getStorageCapacity()
+      .then((value) => ({ status: 'fulfilled' as const, value }))
+      .catch(() => ({ status: 'rejected' as const }));
+
     try {
       const tenants: TenantDto[] = await tenantService.listTenants();
       const results = await Promise.allSettled(
@@ -93,6 +121,14 @@ const TenantMetricsDashboardPage: React.FC = () => {
     } catch {
       toast.error('Failed to load tenants');
     } finally {
+      const capacity = await capacityResult;
+      if (capacity.status === 'fulfilled') {
+        setStorageCapacity(capacity.value);
+      } else {
+        setStorageCapacity(null);
+        setCapacityFailed(true);
+        toast.warn('Failed to load storage capacity');
+      }
       setLoading(false);
     }
   }, []);
@@ -162,14 +198,14 @@ const TenantMetricsDashboardPage: React.FC = () => {
         <Stack spacing={3}>
           {/* Summary Cards */}
           <Grid container spacing={2}>
-            <Grid item xs={12} sm={4}>
+            <Grid item xs={12} sm={6} md={3}>
               <Card variant="outlined">
                 <CardContent>
                   <Stack direction="row" spacing={1.5} alignItems="center">
                     <Storage color="primary" />
                     <Box>
                       <Typography variant="caption" color="text.secondary">
-                        Total Storage Used
+                        Tenant Logical Usage
                       </Typography>
                       <Typography variant="h6">{formatBytes(totalStorageUsed)}</Typography>
                     </Box>
@@ -177,7 +213,45 @@ const TenantMetricsDashboardPage: React.FC = () => {
                 </CardContent>
               </Card>
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid item xs={12} sm={6} md={3}>
+              <Card variant="outlined">
+                <CardContent>
+                  <Stack spacing={1}>
+                    <Stack direction="row" spacing={1.5} alignItems="center" justifyContent="space-between">
+                      <Stack direction="row" spacing={1.5} alignItems="center">
+                        <Storage color="primary" />
+                        <Box>
+                          <Typography variant="caption" color="text.secondary">
+                            Content Store Filesystem (Disk)
+                          </Typography>
+                          <Typography variant="h6">
+                            {storageCapacity
+                              ? `${formatBytes(storageCapacity.usableBytes)} free`
+                              : 'Unavailable'}
+                          </Typography>
+                        </Box>
+                      </Stack>
+                      <Chip
+                        size="small"
+                        label={storageCapacity?.status || 'UNKNOWN'}
+                        color={getCapacityChipColor(storageCapacity?.status)}
+                      />
+                    </Stack>
+                    <Typography variant="caption" color="text.secondary">
+                      {storageCapacity
+                        ? `${formatPercent(storageCapacity.usedPercent)} used of ${formatBytes(storageCapacity.totalBytes)}`
+                        : 'Disk backing content root; upload-block signal.'}
+                    </Typography>
+                    {storageCapacity && (
+                      <Typography variant="caption" color="text.secondary">
+                        Disk backing content root; upload-block signal, separate from tenant logical quota.
+                      </Typography>
+                    )}
+                  </Stack>
+                </CardContent>
+              </Card>
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
               <Card variant="outlined">
                 <CardContent>
                   <Stack direction="row" spacing={1.5} alignItems="center">
@@ -192,7 +266,7 @@ const TenantMetricsDashboardPage: React.FC = () => {
                 </CardContent>
               </Card>
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid item xs={12} sm={6} md={3}>
               <Card variant="outlined">
                 <CardContent>
                   <Stack direction="row" spacing={1.5} alignItems="center">
@@ -208,6 +282,14 @@ const TenantMetricsDashboardPage: React.FC = () => {
               </Card>
             </Grid>
           </Grid>
+
+          {capacityFailed && (
+            <Paper variant="outlined" sx={{ p: 1.5, bgcolor: 'warning.light' }}>
+              <Typography variant="body2">
+                Storage capacity unavailable. Tenant logical metrics are still shown.
+              </Typography>
+            </Paper>
+          )}
 
           {/* Storage Usage Bar Chart */}
           <Paper variant="outlined" sx={{ p: 2 }}>

--- a/ecm-frontend/src/services/tenantService.test.ts
+++ b/ecm-frontend/src/services/tenantService.test.ts
@@ -1,6 +1,7 @@
 import tenantService, {
   DEFAULT_TENANT_DOMAIN,
   TENANT_UNEXPECTED_RESPONSE_MESSAGE,
+  StorageCapacityStatusDto,
   TenantDto,
   TenantMetricsDto,
 } from './tenantService';
@@ -41,6 +42,20 @@ const metrics: TenantMetricsDto = {
   nodeCount: 10,
   documentCount: 6,
   folderCount: 4,
+};
+
+const capacity: StorageCapacityStatusDto = {
+  backendType: 'filesystem',
+  status: 'WARN',
+  totalBytes: 1000,
+  usableBytes: 150,
+  usedBytes: 850,
+  usedPercent: 85,
+  warnPercent: 80,
+  criticalPercent: 95,
+  blockedMinFreeBytes: 104857600,
+  rootPath: '/var/ecm/content',
+  error: null,
 };
 
 describe('tenantService active tenant helpers', () => {
@@ -146,6 +161,14 @@ describe('tenantService api wrappers', () => {
     expect(mockedApi.get).toHaveBeenCalledWith('/admin/tenants/acme%20corp/metrics');
   });
 
+  it('fetches physical storage capacity from the admin endpoint', async () => {
+    mockedApi.get.mockResolvedValueOnce(capacity);
+
+    await expect(tenantService.getStorageCapacity()).resolves.toEqual(capacity);
+
+    expect(mockedApi.get).toHaveBeenCalledWith('/admin/storage/capacity');
+  });
+
   it('rejects HTML fallback for tenant lists', async () => {
     mockedApi.get.mockResolvedValueOnce('<!doctype html><html></html>');
 
@@ -169,6 +192,17 @@ describe('tenantService api wrappers', () => {
     });
 
     await expect(tenantService.getTenantMetrics('acme')).rejects.toThrow(
+      TENANT_UNEXPECTED_RESPONSE_MESSAGE
+    );
+  });
+
+  it('rejects malformed storage capacity status', async () => {
+    mockedApi.get.mockResolvedValueOnce({
+      ...capacity,
+      status: 'FULL',
+    });
+
+    await expect(tenantService.getStorageCapacity()).rejects.toThrow(
       TENANT_UNEXPECTED_RESPONSE_MESSAGE
     );
   });

--- a/ecm-frontend/src/services/tenantService.ts
+++ b/ecm-frontend/src/services/tenantService.ts
@@ -41,6 +41,20 @@ export interface TenantMetricsDto {
   folderCount: number;
 }
 
+export interface StorageCapacityStatusDto {
+  backendType: string;
+  status: 'OK' | 'WARN' | 'CRITICAL' | 'BLOCKED' | 'UNKNOWN';
+  totalBytes: number;
+  usableBytes: number;
+  usedBytes: number;
+  usedPercent: number;
+  warnPercent: number;
+  criticalPercent: number;
+  blockedMinFreeBytes: number;
+  rootPath: string;
+  error?: string | null;
+}
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -49,6 +63,13 @@ const isNullableString = (value: unknown): value is string | null | undefined =>
 
 const isNullableNumber = (value: unknown): value is number | null | undefined =>
   value === null || value === undefined || typeof value === 'number';
+
+const isStorageCapacityStatus = (value: unknown): value is StorageCapacityStatusDto['status'] =>
+  value === 'OK'
+  || value === 'WARN'
+  || value === 'CRITICAL'
+  || value === 'BLOCKED'
+  || value === 'UNKNOWN';
 
 function assertTenantResponse(condition: unknown): asserts condition {
   if (!condition) {
@@ -91,6 +112,23 @@ const assertTenantMetrics = (value: unknown): TenantMetricsDto => {
   return value as unknown as TenantMetricsDto;
 };
 
+const assertStorageCapacityStatus = (value: unknown): StorageCapacityStatusDto => {
+  assertTenantResponse(isRecord(value));
+  assertTenantResponse(typeof value.backendType === 'string');
+  assertTenantResponse(isStorageCapacityStatus(value.status));
+  assertTenantResponse(typeof value.totalBytes === 'number');
+  assertTenantResponse(typeof value.usableBytes === 'number');
+  assertTenantResponse(typeof value.usedBytes === 'number');
+  assertTenantResponse(typeof value.usedPercent === 'number');
+  assertTenantResponse(typeof value.warnPercent === 'number');
+  assertTenantResponse(typeof value.criticalPercent === 'number');
+  assertTenantResponse(typeof value.blockedMinFreeBytes === 'number');
+  assertTenantResponse(typeof value.rootPath === 'string');
+  assertTenantResponse(isNullableString(value.error));
+
+  return value as unknown as StorageCapacityStatusDto;
+};
+
 class TenantService {
   async listTenants(): Promise<TenantDto[]> {
     const result = await api.get<unknown>('/admin/tenants');
@@ -110,6 +148,11 @@ class TenantService {
   async getTenantMetrics(tenantDomain: string): Promise<TenantMetricsDto> {
     const result = await api.get<unknown>(`/admin/tenants/${encodeURIComponent(tenantDomain)}/metrics`);
     return assertTenantMetrics(result);
+  }
+
+  async getStorageCapacity(): Promise<StorageCapacityStatusDto> {
+    const result = await api.get<unknown>('/admin/storage/capacity');
+    return assertStorageCapacityStatus(result);
   }
 
   async createTenant(payload: TenantMutationRequest): Promise<TenantDto> {


### PR DESCRIPTION
Summary

- Adds an admin-only read-only storage capacity endpoint at `/api/admin/storage/capacity` and `/api/v1/admin/storage/capacity`.
- Probes the filesystem backing `ecm.storage.root-path` with `Files.getFileStore(...)`; no MinIO/S3 client, no storage routing, no quota/enforcement change.
- Adds threshold status (`OK`, `WARN`, `CRITICAL`, `BLOCKED`, `UNKNOWN`) with defaults 80 / 95 / 100MiB; `BLOCKED` is observability-only in this slice.
- Extends `TenantMetricsDashboardPage` with a `Content Store Filesystem (Disk)` card and relabels the existing aggregate as `Tenant Logical Usage`.
- Updates the Day-1 taskbook wording so the UI/docs do not imply Athena content-byte or deduped-blob accounting.

Test plan

- [x] `cd ecm-core && ./mvnw -q -Dtest=StorageCapacityServiceTest,StorageAdminControllerTest,StorageAdminControllerSecurityTest test`
- [x] `cd ecm-frontend && npm test -- --watchAll=false TenantMetricsDashboardPage tenantService`
- [x] `git diff --cached --check`

Notes

- Capacity fetch failure is isolated from existing tenant metrics rendering.
- Missing content root returns `UNKNOWN` without creating directories.
- Per-tenant quota metrics remain the frozen ADR-002 logical model.
