### PR TITLE
feat(oauth): support Microsoft local-clear revoke

### DIFF
--- a/docs/DEVELOPMENT_MS_OAUTH_REVOKE_TASKBOOK_20260625.md
+++ b/docs/DEVELOPMENT_MS_OAUTH_REVOKE_TASKBOOK_20260625.md
@@ -1,7 +1,8 @@
 # Microsoft OAuth Revoke — Day-1 Taskbook / Gap Audit
 
 - Date: 2026-06-25
-- Status: Day-1 **read-only gap audit + taskbook; RATIFIED for Day-2 build.**
+- Status: Day-1 **read-only gap audit + taskbook; RATIFIED for Day-2 build.** Day-2 implementation updates these
+  pre-build facts to the §3(A) LOCAL-CLEAR semantics.
 - Scope: Athena OAuth credential **revoke** for the `MICROSOFT` provider.
 - Ratified decision: **§3(A) LOCAL-CLEAR revoke**.
 
@@ -17,7 +18,7 @@ cached session so Athena immediately stops using that credential. It must not ca
 (none exists for per-token revoke), must not invoke Microsoft Graph `revokeSignInSessions`, and must label the action
 honestly as **local token clear, not Entra-side session revocation**.
 
-## 1. Current code facts (grounded)
+## 1. Day-1 pre-build code facts (grounded)
 
 - `OAuthProviderType { GOOGLE, MICROSOFT, CUSTOM }`. Microsoft has connect/token URLs + scope
   (`MICROSOFT_AUTH_URL_TEMPLATE`, `MICROSOFT_TOKEN_URL_TEMPLATE`, `MICROSOFT_SCOPE_DEFAULT` = `outlook.office.com` IMAP).

--- a/docs/MICROSOFT_OAUTH_PROVIDER_REVOKE_DESIGN_20260524.md
+++ b/docs/MICROSOFT_OAUTH_PROVIDER_REVOKE_DESIGN_20260524.md
@@ -2,6 +2,10 @@
 
 Date: 2026-05-24
 
+> **Superseded 2026-06-25:** `docs/DEVELOPMENT_MS_OAUTH_REVOKE_TASKBOOK_20260625.md`
+> ratified Microsoft **LOCAL-CLEAR** revoke semantics. This brief remains historical
+> discovery context and must not be used as current implementation guidance.
+
 ## Headline
 
 **The existing codebase already implements the position recommended by the design doc** `docs/OAUTH_CREDENTIAL_PROVIDER_REVOKE_MICROSOFT_CUSTOM_DESIGN_FOLLOWUP_20260507.md` §52-57 — Microsoft is intentionally unsupported and the limitation is surfaced honestly through capability metadata at both the dynamic service-layer decision and the static inventory-projection decision. No code change is required to satisfy the design doc.

--- a/ecm-core/src/main/java/com/ecm/core/controller/OAuthCredentialAdminController.java
+++ b/ecm-core/src/main/java/com/ecm/core/controller/OAuthCredentialAdminController.java
@@ -62,9 +62,10 @@ public class OAuthCredentialAdminController {
 
     @PostMapping("/{credentialId}/revoke")
     @Operation(
-        summary = "Revoke OAuth credential at provider",
-        description = "Calls the provider's revoke endpoint. GOOGLE is built in; CUSTOM requires a configured revoke "
-            + "endpoint. On success or already-invalid-token "
+        summary = "Revoke or locally clear OAuth credential",
+        description = "Calls the provider's revoke endpoint for GOOGLE and configured CUSTOM credentials. "
+            + "MICROSOFT performs a local token clear only because Entra has no per-token revoke endpoint. "
+            + "On success or already-invalid-token "
             + "responses, clears local tokens and returns the redacted inventory row. On 5xx or network failure, "
             + "preserves local tokens and surfaces a diagnostic error."
     )

--- a/ecm-core/src/main/java/com/ecm/core/integration/oauth/OAuthCredentialAdminService.java
+++ b/ecm-core/src/main/java/com/ecm/core/integration/oauth/OAuthCredentialAdminService.java
@@ -110,26 +110,32 @@ public class OAuthCredentialAdminService {
     }
 
     private static OAuthProviderRevokeCapability staticCapability(OAuthCredentialInventoryItem item) {
-        boolean supported;
-        String reason;
         if (item.provider() == null) {
-            supported = false;
-            reason = "Provider-side revoke is only supported for GOOGLE or CUSTOM; this credential is null";
-        } else if (item.provider() == OAuthProviderType.MICROSOFT) {
-            supported = false;
-            reason = "Provider-side revoke is not yet supported for MICROSOFT";
-        } else if (item.accessTokenStored() || item.refreshTokenStored()) {
-            supported = item.provider() == OAuthProviderType.GOOGLE;
-            reason = supported ? null : "Provider-side revoke endpoint is not configured for this CUSTOM credential";
-        } else if (item.credentialKeyConfigured()) {
-            supported = false;
-            reason = "Provider-side revoke requires a locally stored OAuth token; "
-                + "this credential row only references env-managed secrets";
-        } else {
-            supported = false;
-            reason = "No locally stored OAuth token to revoke";
+            return new OAuthProviderRevokeCapability(
+                false,
+                "OAuth revoke is only supported for GOOGLE, MICROSOFT, or CUSTOM; this credential is null"
+            );
         }
-        return new OAuthProviderRevokeCapability(supported, reason);
+        if (item.credentialKeyConfigured() && !item.accessTokenStored() && !item.refreshTokenStored()) {
+            return new OAuthProviderRevokeCapability(
+                false,
+                "Provider-side revoke requires a locally stored OAuth token; "
+                    + "this credential row only references env-managed secrets"
+            );
+        }
+        if (!item.accessTokenStored() && !item.refreshTokenStored()) {
+            return new OAuthProviderRevokeCapability(false, "No locally stored OAuth token to revoke");
+        }
+        if (item.provider() == OAuthProviderType.MICROSOFT) {
+            return new OAuthProviderRevokeCapability(true, null, OAuthRevokeCapabilityMode.LOCAL_CLEAR);
+        }
+        if (item.provider() == OAuthProviderType.GOOGLE) {
+            return new OAuthProviderRevokeCapability(true, null);
+        }
+        return new OAuthProviderRevokeCapability(
+            false,
+            "Provider-side revoke endpoint is not configured for this CUSTOM credential"
+        );
     }
 
     private static OAuthCredentialInventoryItem withCapability(
@@ -153,7 +159,8 @@ public class OAuthCredentialAdminService {
             item.createdAt(),
             item.updatedAt(),
             capability.supported(),
-            capability.unsupportedReason()
+            capability.unsupportedReason(),
+            capability.mode()
         );
     }
 

--- a/ecm-core/src/main/java/com/ecm/core/integration/oauth/OAuthCredentialInventoryItem.java
+++ b/ecm-core/src/main/java/com/ecm/core/integration/oauth/OAuthCredentialInventoryItem.java
@@ -20,8 +20,50 @@ public record OAuthCredentialInventoryItem(
     LocalDateTime createdAt,
     LocalDateTime updatedAt,
     boolean providerRevokeSupported,
-    String providerRevokeUnsupportedReason
+    String providerRevokeUnsupportedReason,
+    OAuthRevokeCapabilityMode providerRevokeMode
 ) {
+    public OAuthCredentialInventoryItem(
+        UUID id,
+        String ownerType,
+        UUID ownerId,
+        OAuthProviderType provider,
+        boolean tokenEndpointConfigured,
+        boolean revokeEndpointConfigured,
+        boolean tenantIdConfigured,
+        boolean scopeConfigured,
+        boolean credentialKeyConfigured,
+        boolean accessTokenStored,
+        boolean refreshTokenStored,
+        boolean connected,
+        LocalDateTime tokenExpiresAt,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        boolean providerRevokeSupported,
+        String providerRevokeUnsupportedReason
+    ) {
+        this(
+            id,
+            ownerType,
+            ownerId,
+            provider,
+            tokenEndpointConfigured,
+            revokeEndpointConfigured,
+            tenantIdConfigured,
+            scopeConfigured,
+            credentialKeyConfigured,
+            accessTokenStored,
+            refreshTokenStored,
+            connected,
+            tokenExpiresAt,
+            createdAt,
+            updatedAt,
+            providerRevokeSupported,
+            providerRevokeUnsupportedReason,
+            defaultMode(providerRevokeSupported)
+        );
+    }
+
     public OAuthCredentialInventoryItem(
         UUID id,
         String ownerType,
@@ -57,7 +99,14 @@ public record OAuthCredentialInventoryItem(
             createdAt,
             updatedAt,
             providerRevokeSupported,
-            providerRevokeUnsupportedReason
+            providerRevokeUnsupportedReason,
+            defaultMode(providerRevokeSupported)
         );
+    }
+
+    private static OAuthRevokeCapabilityMode defaultMode(boolean providerRevokeSupported) {
+        return providerRevokeSupported
+            ? OAuthRevokeCapabilityMode.PROVIDER_REVOKE
+            : OAuthRevokeCapabilityMode.UNSUPPORTED;
     }
 }

--- a/ecm-core/src/main/java/com/ecm/core/integration/oauth/OAuthCredentialService.java
+++ b/ecm-core/src/main/java/com/ecm/core/integration/oauth/OAuthCredentialService.java
@@ -43,8 +43,8 @@ public class OAuthCredentialService {
     private static final String NO_LOCAL_TOKEN_REVOKE_UNSUPPORTED = "No locally stored OAuth token to revoke";
     private static final String CUSTOM_REVOKE_ENDPOINT_UNCONFIGURED =
         "Provider-side revoke endpoint is not configured for this CUSTOM credential";
-    private static final String MICROSOFT_REVOKE_UNSUPPORTED =
-        "Provider-side revoke is not yet supported for MICROSOFT";
+    private static final String OAUTH_REVOKE_PROVIDER_UNSUPPORTED =
+        "OAuth revoke is only supported for GOOGLE, MICROSOFT, or CUSTOM";
 
     private final Environment environment;
     private final RestTemplate restTemplate;
@@ -181,10 +181,13 @@ public class OAuthCredentialService {
     }
 
     /**
-     * Calls the provider's revoke endpoint for the locally stored OAuth token.
+     * Revokes or locally clears a stored OAuth credential.
      *
-     * <p>Supports GOOGLE and CUSTOM credentials with a configured revoke endpoint. Prefers the
-     * stored refresh token; falls back to the access token.
+     * <p>GOOGLE and CUSTOM credentials call a provider revoke endpoint. MICROSOFT performs
+     * a local token clear only because Microsoft Entra does not expose a per-token revoke
+     * endpoint equivalent to RFC 7009.
+     *
+     * <p>Provider revoke prefers the stored refresh token and falls back to the access token.
      * On HTTP 200 OR provider-side already-invalid responses (HTTP 4xx with error in
      * {invalid_token, invalid_grant, unsupported_token_type}), local tokens are cleared and the
      * session cache is evicted. On HTTP 5xx, network failures, or any other error, local tokens
@@ -196,6 +199,11 @@ public class OAuthCredentialService {
         ResolvedProviderRevokeCapability capability = resolveProviderRevokeCapability(context);
         if (!capability.supported()) {
             throw new IllegalArgumentException(capability.unsupportedReason());
+        }
+        if (capability.mode() == OAuthRevokeCapabilityMode.LOCAL_CLEAR) {
+            context.adapter().clearTokens(owner.ownerId());
+            evictSession(owner.ownerType(), owner.ownerId());
+            return;
         }
 
         boolean hasAccessToken = owner.accessToken() != null && !owner.accessToken().isBlank();
@@ -264,7 +272,11 @@ public class OAuthCredentialService {
 
     public OAuthProviderRevokeCapability providerRevokeCapability(String ownerType, UUID ownerId) {
         ResolvedProviderRevokeCapability capability = resolveProviderRevokeCapability(loadContext(ownerType, ownerId));
-        return new OAuthProviderRevokeCapability(capability.supported(), capability.unsupportedReason());
+        return new OAuthProviderRevokeCapability(
+            capability.supported(),
+            capability.unsupportedReason(),
+            capability.mode()
+        );
     }
 
     private ResolvedProviderRevokeCapability resolveProviderRevokeCapability(AdapterContext context) {
@@ -273,13 +285,12 @@ public class OAuthCredentialService {
         boolean hasRefreshToken = owner.refreshToken() != null && !owner.refreshToken().isBlank();
 
         if (owner.provider() == null) {
-            return unsupported("Provider-side revoke is only supported for GOOGLE or CUSTOM; this credential is null");
+            return unsupported(OAUTH_REVOKE_PROVIDER_UNSUPPORTED + "; this credential is null");
         }
-        if (owner.provider() == OAuthProviderType.MICROSOFT) {
-            return unsupported(MICROSOFT_REVOKE_UNSUPPORTED);
-        }
-        if (owner.provider() != OAuthProviderType.GOOGLE && owner.provider() != OAuthProviderType.CUSTOM) {
-            return unsupported("Provider-side revoke is only supported for GOOGLE or CUSTOM; this credential is " + owner.provider());
+        if (owner.provider() != OAuthProviderType.GOOGLE
+            && owner.provider() != OAuthProviderType.MICROSOFT
+            && owner.provider() != OAuthProviderType.CUSTOM) {
+            return unsupported(OAUTH_REVOKE_PROVIDER_UNSUPPORTED + "; this credential is " + owner.provider());
         }
         if (hasCredentialKey(owner) && !hasAccessToken && !hasRefreshToken) {
             return unsupported(ENV_MANAGED_REVOKE_UNSUPPORTED);
@@ -287,19 +298,37 @@ public class OAuthCredentialService {
         if (!hasAccessToken && !hasRefreshToken) {
             return unsupported(NO_LOCAL_TOKEN_REVOKE_UNSUPPORTED);
         }
+        if (owner.provider() == OAuthProviderType.MICROSOFT) {
+            return new ResolvedProviderRevokeCapability(
+                true,
+                null,
+                null,
+                OAuthRevokeCapabilityMode.LOCAL_CLEAR
+            );
+        }
         if (owner.provider() == OAuthProviderType.GOOGLE) {
-            return new ResolvedProviderRevokeCapability(true, null, GOOGLE_REVOKE_URL);
+            return new ResolvedProviderRevokeCapability(
+                true,
+                null,
+                GOOGLE_REVOKE_URL,
+                OAuthRevokeCapabilityMode.PROVIDER_REVOKE
+            );
         }
 
         String revokeEndpoint = resolveCustomRevokeEndpoint(context);
         if (revokeEndpoint == null || revokeEndpoint.isBlank()) {
             return unsupported(CUSTOM_REVOKE_ENDPOINT_UNCONFIGURED);
         }
-        return new ResolvedProviderRevokeCapability(true, null, revokeEndpoint);
+        return new ResolvedProviderRevokeCapability(
+            true,
+            null,
+            revokeEndpoint,
+            OAuthRevokeCapabilityMode.PROVIDER_REVOKE
+        );
     }
 
     private ResolvedProviderRevokeCapability unsupported(String reason) {
-        return new ResolvedProviderRevokeCapability(false, reason, null);
+        return new ResolvedProviderRevokeCapability(false, reason, null, OAuthRevokeCapabilityMode.UNSUPPORTED);
     }
 
     private boolean isAlreadyInvalidTokenError(String error) {
@@ -648,7 +677,8 @@ public class OAuthCredentialService {
     private record ResolvedProviderRevokeCapability(
         boolean supported,
         String unsupportedReason,
-        String revokeEndpoint
+        String revokeEndpoint,
+        OAuthRevokeCapabilityMode mode
     ) {
     }
 

--- a/ecm-core/src/main/java/com/ecm/core/integration/oauth/OAuthProviderRevokeCapability.java
+++ b/ecm-core/src/main/java/com/ecm/core/integration/oauth/OAuthProviderRevokeCapability.java
@@ -2,6 +2,12 @@ package com.ecm.core.integration.oauth;
 
 public record OAuthProviderRevokeCapability(
     boolean supported,
-    String unsupportedReason
+    String unsupportedReason,
+    OAuthRevokeCapabilityMode mode
 ) {
+    public OAuthProviderRevokeCapability(boolean supported, String unsupportedReason) {
+        this(supported, unsupportedReason, supported
+            ? OAuthRevokeCapabilityMode.PROVIDER_REVOKE
+            : OAuthRevokeCapabilityMode.UNSUPPORTED);
+    }
 }

--- a/ecm-core/src/main/java/com/ecm/core/integration/oauth/OAuthRevokeCapabilityMode.java
+++ b/ecm-core/src/main/java/com/ecm/core/integration/oauth/OAuthRevokeCapabilityMode.java
@@ -1,0 +1,7 @@
+package com.ecm.core.integration.oauth;
+
+public enum OAuthRevokeCapabilityMode {
+    PROVIDER_REVOKE,
+    LOCAL_CLEAR,
+    UNSUPPORTED
+}

--- a/ecm-core/src/test/java/com/ecm/core/controller/OAuthCredentialAdminControllerSecurityTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/OAuthCredentialAdminControllerSecurityTest.java
@@ -5,6 +5,7 @@ import com.ecm.core.integration.oauth.OAuthCredentialInventoryItem;
 import com.ecm.core.integration.oauth.OAuthCredentialRevokeEndpointDetails;
 import com.ecm.core.integration.oauth.OAuthReauthRequiredException;
 import com.ecm.core.integration.oauth.OAuthProviderType;
+import com.ecm.core.integration.oauth.OAuthRevokeCapabilityMode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -149,6 +150,7 @@ class OAuthCredentialAdminControllerSecurityTest {
             // off these two fields instead of hard-coding `provider === 'GOOGLE'`.
             .andExpect(jsonPath("$[0].providerRevokeSupported", is(true)))
             .andExpect(jsonPath("$[0].providerRevokeUnsupportedReason").doesNotExist())
+            .andExpect(jsonPath("$[0].providerRevokeMode", is("PROVIDER_REVOKE")))
             .andExpect(jsonPath("$[0].accessToken").doesNotExist())
             .andExpect(jsonPath("$[0].refreshToken").doesNotExist());
 
@@ -190,6 +192,7 @@ class OAuthCredentialAdminControllerSecurityTest {
             .andExpect(jsonPath("$.accessTokenStored", is(false)))
             .andExpect(jsonPath("$.refreshTokenStored", is(false)))
             .andExpect(jsonPath("$.providerRevokeSupported", is(false)))
+            .andExpect(jsonPath("$.providerRevokeMode", is("UNSUPPORTED")))
             .andExpect(jsonPath(
                 "$.providerRevokeUnsupportedReason",
                 is("Provider-side revoke requires a locally stored OAuth token; "
@@ -236,6 +239,7 @@ class OAuthCredentialAdminControllerSecurityTest {
             .andExpect(jsonPath("$.refreshTokenStored", is(true)))
             .andExpect(jsonPath("$.providerRevokeSupported", is(true)))
             .andExpect(jsonPath("$.providerRevokeUnsupportedReason").doesNotExist())
+            .andExpect(jsonPath("$.providerRevokeMode", is("PROVIDER_REVOKE")))
             .andExpect(jsonPath("$.accessToken").doesNotExist())
             .andExpect(jsonPath("$.refreshToken").doesNotExist());
 
@@ -294,6 +298,7 @@ class OAuthCredentialAdminControllerSecurityTest {
             .andExpect(jsonPath("$.accessTokenStored", is(false)))
             .andExpect(jsonPath("$.refreshTokenStored", is(false)))
             .andExpect(jsonPath("$.providerRevokeSupported", is(false)))
+            .andExpect(jsonPath("$.providerRevokeMode", is("UNSUPPORTED")))
             .andExpect(jsonPath(
                 "$.providerRevokeUnsupportedReason",
                 is("Provider-side revoke requires a locally stored OAuth token; "
@@ -307,18 +312,63 @@ class OAuthCredentialAdminControllerSecurityTest {
 
     @Test
     @WithMockUser(roles = "ADMIN")
+    @DisplayName("admin can local-clear Microsoft OAuth credential without token disclosure")
+    void adminCanLocalClearMicrosoftCredential() throws Exception {
+        UUID credentialId = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        UUID ownerId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        when(oauthCredentialAdminService.revokeProvider(credentialId)).thenReturn(
+            new OAuthCredentialInventoryItem(
+                credentialId,
+                "MAIL_ACCOUNT",
+                ownerId,
+                OAuthProviderType.MICROSOFT,
+                true,
+                false,
+                false,
+                true,
+                true,
+                false,
+                false,
+                false,
+                null,
+                LocalDateTime.parse("2026-05-01T09:00:00"),
+                LocalDateTime.parse("2026-05-07T10:00:00"),
+                false,
+                "No locally stored OAuth token to revoke",
+                OAuthRevokeCapabilityMode.UNSUPPORTED
+            )
+        );
+
+        mockMvc.perform(post("/api/v1/admin/oauth-credentials/{credentialId}/revoke", credentialId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id", is(credentialId.toString())))
+            .andExpect(jsonPath("$.provider", is("MICROSOFT")))
+            .andExpect(jsonPath("$.connected", is(false)))
+            .andExpect(jsonPath("$.accessTokenStored", is(false)))
+            .andExpect(jsonPath("$.refreshTokenStored", is(false)))
+            .andExpect(jsonPath("$.providerRevokeSupported", is(false)))
+            .andExpect(jsonPath("$.providerRevokeMode", is("UNSUPPORTED")))
+            .andExpect(jsonPath("$.providerRevokeUnsupportedReason", is("No locally stored OAuth token to revoke")))
+            .andExpect(jsonPath("$.accessToken").doesNotExist())
+            .andExpect(jsonPath("$.refreshToken").doesNotExist());
+
+        verify(oauthCredentialAdminService).revokeProvider(credentialId);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
     @DisplayName("revoke OAuth credential reports unsupported provider as 400")
     void revokeReportsUnsupportedProviderAs400() throws Exception {
         UUID credentialId = UUID.fromString("11111111-2222-3333-4444-555555555555");
         when(oauthCredentialAdminService.revokeProvider(credentialId)).thenThrow(
-            new IllegalArgumentException("Provider-side revoke is not yet supported for MICROSOFT")
+            new IllegalArgumentException("OAuth revoke is only supported for GOOGLE, MICROSOFT, or CUSTOM; this credential is null")
         );
 
         mockMvc.perform(post("/api/v1/admin/oauth-credentials/{credentialId}/revoke", credentialId))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath(
                 "$.message",
-                is("Provider-side revoke is not yet supported for MICROSOFT")
+                is("OAuth revoke is only supported for GOOGLE, MICROSOFT, or CUSTOM; this credential is null")
             ));
 
         verify(oauthCredentialAdminService).revokeProvider(credentialId);
@@ -430,6 +480,7 @@ class OAuthCredentialAdminControllerSecurityTest {
             .andExpect(jsonPath("$.revokeEndpointConfigured", is(true)))
             .andExpect(jsonPath("$.providerRevokeSupported", is(true)))
             .andExpect(jsonPath("$.providerRevokeUnsupportedReason").doesNotExist())
+            .andExpect(jsonPath("$.providerRevokeMode", is("PROVIDER_REVOKE")))
             .andExpect(jsonPath("$.accessToken").doesNotExist())
             .andExpect(jsonPath("$.refreshToken").doesNotExist());
 

--- a/ecm-core/src/test/java/com/ecm/core/integration/oauth/OAuthCredentialAdminServiceTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/integration/oauth/OAuthCredentialAdminServiceTest.java
@@ -60,7 +60,7 @@ class OAuthCredentialAdminServiceTest {
     @Test
     @DisplayName("listCredentials enriches every row with provider-revoke capability metadata")
     void listCredentialsEnrichesEveryRowWithCapability() {
-        // Two rows: a GOOGLE row with stored tokens (supported) and a non-GOOGLE row (unsupported).
+        // Two rows: a GOOGLE row with provider revoke and a MICROSOFT row with local-clear.
         // The repository projection always returns capability-default (false, null), so the service
         // must re-derive both fields per row before returning to the controller.
         UUID googleId = UUID.fromString("11111111-1111-1111-1111-111111111111");
@@ -74,9 +74,10 @@ class OAuthCredentialAdminServiceTest {
         assertEquals(2, result.size());
         assertTrue(result.get(0).providerRevokeSupported());
         assertNull(result.get(0).providerRevokeUnsupportedReason());
-        assertFalse(result.get(1).providerRevokeSupported());
-        assertNotNull(result.get(1).providerRevokeUnsupportedReason());
-        assertTrue(result.get(1).providerRevokeUnsupportedReason().contains("MICROSOFT"));
+        assertEquals(OAuthRevokeCapabilityMode.PROVIDER_REVOKE, result.get(0).providerRevokeMode());
+        assertTrue(result.get(1).providerRevokeSupported());
+        assertNull(result.get(1).providerRevokeUnsupportedReason());
+        assertEquals(OAuthRevokeCapabilityMode.LOCAL_CLEAR, result.get(1).providerRevokeMode());
     }
 
     @Test
@@ -93,6 +94,7 @@ class OAuthCredentialAdminServiceTest {
         assertEquals(1, result.size());
         assertTrue(result.get(0).providerRevokeSupported());
         assertNull(result.get(0).providerRevokeUnsupportedReason());
+        assertEquals(OAuthRevokeCapabilityMode.PROVIDER_REVOKE, result.get(0).providerRevokeMode());
     }
 
     @Test
@@ -104,6 +106,7 @@ class OAuthCredentialAdminServiceTest {
 
         assertTrue(enriched.providerRevokeSupported());
         assertNull(enriched.providerRevokeUnsupportedReason());
+        assertEquals(OAuthRevokeCapabilityMode.PROVIDER_REVOKE, enriched.providerRevokeMode());
     }
 
     @Test
@@ -115,6 +118,7 @@ class OAuthCredentialAdminServiceTest {
 
         assertTrue(enriched.providerRevokeSupported());
         assertNull(enriched.providerRevokeUnsupportedReason());
+        assertEquals(OAuthRevokeCapabilityMode.PROVIDER_REVOKE, enriched.providerRevokeMode());
     }
 
     @Test
@@ -132,6 +136,7 @@ class OAuthCredentialAdminServiceTest {
                 + "this credential row only references env-managed secrets",
             enriched.providerRevokeUnsupportedReason()
         );
+        assertEquals(OAuthRevokeCapabilityMode.UNSUPPORTED, enriched.providerRevokeMode());
     }
 
     @Test
@@ -143,20 +148,19 @@ class OAuthCredentialAdminServiceTest {
 
         assertFalse(enriched.providerRevokeSupported());
         assertEquals("No locally stored OAuth token to revoke", enriched.providerRevokeUnsupportedReason());
+        assertEquals(OAuthRevokeCapabilityMode.UNSUPPORTED, enriched.providerRevokeMode());
     }
 
     @Test
-    @DisplayName("withCapability: MICROSOFT is unsupported with provider-name reason")
-    void withCapabilityMicrosoftIsUnsupported() {
+    @DisplayName("withCapability: MICROSOFT with stored token is local-clear")
+    void withCapabilityMicrosoftWithStoredTokenIsLocalClear() {
         OAuthCredentialInventoryItem item = inventory(UUID.randomUUID(), OAuthProviderType.MICROSOFT, true, true, true);
 
         OAuthCredentialInventoryItem enriched = OAuthCredentialAdminService.withCapability(item);
 
-        assertFalse(enriched.providerRevokeSupported());
-        assertEquals(
-            "Provider-side revoke is not yet supported for MICROSOFT",
-            enriched.providerRevokeUnsupportedReason()
-        );
+        assertTrue(enriched.providerRevokeSupported());
+        assertNull(enriched.providerRevokeUnsupportedReason());
+        assertEquals(OAuthRevokeCapabilityMode.LOCAL_CLEAR, enriched.providerRevokeMode());
     }
 
     @Test
@@ -171,6 +175,7 @@ class OAuthCredentialAdminServiceTest {
             "Provider-side revoke endpoint is not configured for this CUSTOM credential",
             enriched.providerRevokeUnsupportedReason()
         );
+        assertEquals(OAuthRevokeCapabilityMode.UNSUPPORTED, enriched.providerRevokeMode());
     }
 
     @Test
@@ -184,9 +189,10 @@ class OAuthCredentialAdminServiceTest {
 
         assertFalse(enriched.providerRevokeSupported());
         assertEquals(
-            "Provider-side revoke is only supported for GOOGLE or CUSTOM; this credential is null",
+            "OAuth revoke is only supported for GOOGLE, MICROSOFT, or CUSTOM; this credential is null",
             enriched.providerRevokeUnsupportedReason()
         );
+        assertEquals(OAuthRevokeCapabilityMode.UNSUPPORTED, enriched.providerRevokeMode());
     }
 
     @Test

--- a/ecm-core/src/test/java/com/ecm/core/integration/oauth/OAuthCredentialServiceTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/integration/oauth/OAuthCredentialServiceTest.java
@@ -318,8 +318,8 @@ class OAuthCredentialServiceTest {
     }
 
     @Test
-    @DisplayName("revokeProviderTokens rejects Microsoft because per-token revoke is not supported")
-    void revokeProviderTokensRejectsMicrosoftProvider() {
+    @DisplayName("revokeProviderTokens local-clears Microsoft without a provider call")
+    void revokeProviderTokensLocalClearsMicrosoftWithoutProviderCall() {
         UUID ownerId = UUID.randomUUID();
         OAuthCredentialOwner owner = new OAuthCredentialOwner(
             OWNER_TYPE,
@@ -336,12 +336,36 @@ class OAuthCredentialServiceTest {
         );
         when(adapter.loadOwner(ownerId)).thenReturn(owner);
 
-        IllegalArgumentException ex = assertThrows(
-            IllegalArgumentException.class,
-            () -> service.revokeProviderTokens(OWNER_TYPE, ownerId)
+        service.revokeProviderTokens(OWNER_TYPE, ownerId);
+
+        verify(adapter).clearTokens(ownerId);
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("providerRevokeCapability reports Microsoft local-clear mode")
+    void providerRevokeCapabilityReportsMicrosoftLocalClearMode() {
+        UUID ownerId = UUID.randomUUID();
+        OAuthCredentialOwner owner = new OAuthCredentialOwner(
+            OWNER_TYPE,
+            ownerId,
+            "outlook",
+            OAuthProviderType.MICROSOFT,
+            null,
+            null,
+            null,
+            null,
+            "access",
+            "refresh",
+            null
         );
-        assertEquals("Provider-side revoke is not yet supported for MICROSOFT", ex.getMessage());
-        verify(adapter, never()).clearTokens(any());
+        when(adapter.loadOwner(ownerId)).thenReturn(owner);
+
+        OAuthProviderRevokeCapability capability = service.providerRevokeCapability(OWNER_TYPE, ownerId);
+
+        assertTrue(capability.supported());
+        assertEquals(OAuthRevokeCapabilityMode.LOCAL_CLEAR, capability.mode());
+        assertEquals(null, capability.unsupportedReason());
     }
 
     @Test

--- a/ecm-frontend/src/pages/OAuthCredentialAdminPage.test.tsx
+++ b/ecm-frontend/src/pages/OAuthCredentialAdminPage.test.tsx
@@ -36,6 +36,7 @@ const credential = {
   updatedAt: '2026-05-06T10:00:00Z',
   providerRevokeSupported: true,
   providerRevokeUnsupportedReason: null,
+  providerRevokeMode: 'PROVIDER_REVOKE',
 };
 
 const LocationProbe: React.FC = () => {
@@ -126,7 +127,7 @@ test('hydrates owner type and provider filters from URL state', async () => {
 
 test('clears owner type and provider URL state while preserving revoke capability filter', async () => {
   renderPage('/admin/oauth-credentials?ownerType=MAIL_ACCOUNT&provider=GOOGLE&revokeCapability=blocked');
-  await screen.findByText('No OAuth credentials are currently blocked from Provider Revoke.');
+  await screen.findByText('No OAuth credentials are currently blocked from revoke/local-clear action.');
 
   fireEvent.change(screen.getByLabelText('Owner type'), { target: { value: '' } });
   fireEvent.change(screen.getByLabelText('Provider'), { target: { value: '' } });
@@ -143,12 +144,12 @@ test('clears owner type and provider URL state while preserving revoke capabilit
 
 test('shows active filter chips from URL state and clears all admin filters', async () => {
   renderPage('/admin/oauth-credentials?view=ops&ownerType=MAIL_ACCOUNT&provider=GOOGLE&revokeCapability=blocked');
-  await screen.findByText('No OAuth credentials are currently blocked from Provider Revoke.');
+  await screen.findByText('No OAuth credentials are currently blocked from revoke/local-clear action.');
 
   expect(screen.getByText('Active filters')).toBeTruthy();
   expect(screen.getByText('Owner type: MAIL_ACCOUNT')).toBeTruthy();
   expect(screen.getByText('Provider: GOOGLE')).toBeTruthy();
-  expect(screen.getByText('Revoke capability: Provider revoke blocked')).toBeTruthy();
+  expect(screen.getByText('Revoke capability: Revoke action blocked')).toBeTruthy();
 
   fireEvent.click(screen.getByRole('button', { name: 'Clear all filters' }));
 
@@ -210,8 +211,8 @@ test('filters to CUSTOM credentials missing a revoke endpoint', async () => {
       ownerId: 'microsoft-owner',
       provider: 'MICROSOFT',
       providerRevokeSupported: false,
-      providerRevokeUnsupportedReason:
-        'Provider-side revoke is only supported for GOOGLE; this credential is MICROSOFT',
+      providerRevokeUnsupportedReason: 'No locally stored OAuth token to revoke',
+      providerRevokeMode: 'UNSUPPORTED',
     },
   ]);
 
@@ -229,7 +230,7 @@ test('filters to CUSTOM credentials missing a revoke endpoint', async () => {
   expect(within(inventoryTable).queryByText('microsoft-owner')).toBeNull();
 });
 
-test('filters to Provider Revoke ready credentials', async () => {
+test('filters to revoke/local-clear ready credentials', async () => {
   mockedOAuthCredentialAdminService.listCredentials.mockResolvedValue([
     {
       ...credential,
@@ -246,22 +247,23 @@ test('filters to Provider Revoke ready credentials', async () => {
       provider: 'CUSTOM',
       providerRevokeSupported: false,
       providerRevokeUnsupportedReason: 'Provider-side revoke endpoint is not configured for this CUSTOM credential',
+      providerRevokeMode: 'UNSUPPORTED',
     },
   ]);
 
   renderPage();
   await screen.findByText('google-ready-owner');
 
-  fireEvent.click(screen.getByRole('button', { name: 'Provider revoke ready (1)' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Revoke action ready (1)' }));
 
-  expect(screen.getByText('Showing credentials where Provider Revoke is currently actionable.')).toBeTruthy();
+  expect(screen.getByText('Showing credentials where OAuth revoke/local-clear is currently actionable.')).toBeTruthy();
   const inventoryTable = screen.getByRole('table', { name: 'OAuth credential inventory' });
   expect(within(inventoryTable).getByText('google-ready-owner')).toBeTruthy();
   expect(within(inventoryTable).queryByText('custom-blocked-owner')).toBeNull();
   expect(screen.getByTestId('location-search').textContent).toBe('?revokeCapability=ready');
 });
 
-test('filters to Provider Revoke blocked credentials and can return to all rows', async () => {
+test('filters to revoke/local-clear blocked credentials and can return to all rows', async () => {
   mockedOAuthCredentialAdminService.listCredentials.mockResolvedValue([
     {
       ...credential,
@@ -277,18 +279,18 @@ test('filters to Provider Revoke blocked credentials and can return to all rows'
       ownerId: 'microsoft-blocked-owner',
       provider: 'MICROSOFT',
       providerRevokeSupported: false,
-      providerRevokeUnsupportedReason:
-        'Provider-side revoke is only supported for GOOGLE; this credential is MICROSOFT',
+      providerRevokeUnsupportedReason: 'No locally stored OAuth token to revoke',
+      providerRevokeMode: 'UNSUPPORTED',
     },
   ]);
 
   renderPage();
   await screen.findByText('google-ready-owner');
 
-  fireEvent.click(screen.getByRole('button', { name: 'Provider revoke blocked (1)' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Revoke action blocked (1)' }));
 
   expect(
-    screen.getByText('Showing credentials where Provider Revoke is blocked by backend capability metadata.')
+    screen.getByText('Showing credentials where OAuth revoke/local-clear is blocked by backend capability metadata.')
   ).toBeTruthy();
   const inventoryTable = screen.getByRole('table', { name: 'OAuth credential inventory' });
   expect(within(inventoryTable).queryByText('google-ready-owner')).toBeNull();
@@ -302,7 +304,7 @@ test('filters to Provider Revoke blocked credentials and can return to all rows'
   expect(screen.getByTestId('location-search').textContent).toBe('');
 });
 
-test('hydrates and clears the Provider Revoke capability filter from URL state', async () => {
+test('hydrates and clears the revoke capability filter from URL state', async () => {
   mockedOAuthCredentialAdminService.listCredentials.mockResolvedValue([
     {
       ...credential,
@@ -318,8 +320,8 @@ test('hydrates and clears the Provider Revoke capability filter from URL state',
       ownerId: 'microsoft-blocked-owner',
       provider: 'MICROSOFT',
       providerRevokeSupported: false,
-      providerRevokeUnsupportedReason:
-        'Provider-side revoke is only supported for GOOGLE; this credential is MICROSOFT',
+      providerRevokeUnsupportedReason: 'No locally stored OAuth token to revoke',
+      providerRevokeMode: 'UNSUPPORTED',
     },
   ]);
 
@@ -520,6 +522,7 @@ test('Provider Revoke is disabled when backend reports providerRevokeSupported=f
       provider: 'GOOGLE',
       providerRevokeSupported: false,
       providerRevokeUnsupportedReason: 'No locally stored OAuth token to revoke',
+      providerRevokeMode: 'UNSUPPORTED',
     },
   ]);
 
@@ -530,19 +533,37 @@ test('Provider Revoke is disabled when backend reports providerRevokeSupported=f
   expect((button as HTMLButtonElement).disabled).toBe(true);
 });
 
-test('Provider Revoke is disabled for non-GOOGLE rows when backend reports unsupported', async () => {
+test('Local Clear is enabled for Microsoft rows with a stored token', async () => {
   mockedOAuthCredentialAdminService.listCredentials.mockResolvedValue([
     {
       ...credential,
       provider: 'MICROSOFT',
-      providerRevokeSupported: false,
-      providerRevokeUnsupportedReason:
-        'Provider-side revoke is only supported for GOOGLE; this credential is MICROSOFT',
+      providerRevokeSupported: true,
+      providerRevokeUnsupportedReason: null,
+      providerRevokeMode: 'LOCAL_CLEAR',
     },
   ]);
 
   renderPage();
   await screen.findByText('MICROSOFT');
+
+  const button = await screen.findByRole('button', { name: 'Local Clear' });
+  expect((button as HTMLButtonElement).disabled).toBe(false);
+});
+
+test('Provider Revoke is disabled for non-GOOGLE rows when backend reports unsupported', async () => {
+  mockedOAuthCredentialAdminService.listCredentials.mockResolvedValue([
+    {
+      ...credential,
+      provider: 'CUSTOM',
+      providerRevokeSupported: false,
+      providerRevokeUnsupportedReason: 'Provider-side revoke endpoint is not configured for this CUSTOM credential',
+      providerRevokeMode: 'UNSUPPORTED',
+    },
+  ]);
+
+  renderPage();
+  await screen.findByText('CUSTOM');
 
   const button = await screen.findByRole('button', { name: 'Provider Revoke' });
   expect((button as HTMLButtonElement).disabled).toBe(true);
@@ -553,13 +574,14 @@ test('Provider Revoke surfaces the backend unsupported reason via tooltip wrappe
   // MUI Tooltip title and an aria-label, so the disabled-button case stays
   // observable without hover-based testing-library queries (the existing
   // tests in this file all use fireEvent, not userEvent).
-  const reason = 'Provider-side revoke is only supported for GOOGLE; this credential is MICROSOFT';
+  const reason = 'No locally stored OAuth token to revoke';
   mockedOAuthCredentialAdminService.listCredentials.mockResolvedValue([
     {
       ...credential,
       provider: 'MICROSOFT',
       providerRevokeSupported: false,
       providerRevokeUnsupportedReason: reason,
+      providerRevokeMode: 'UNSUPPORTED',
     },
   ]);
 
@@ -568,6 +590,46 @@ test('Provider Revoke surfaces the backend unsupported reason via tooltip wrappe
 
   const wrapper = await screen.findByLabelText(reason);
   expect(wrapper).toBeTruthy();
+});
+
+test('local-clears Microsoft OAuth tokens with Entra caveat in confirmation', async () => {
+  const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+  mockedOAuthCredentialAdminService.listCredentials.mockResolvedValue([
+    {
+      ...credential,
+      provider: 'MICROSOFT',
+      providerRevokeSupported: true,
+      providerRevokeUnsupportedReason: null,
+      providerRevokeMode: 'LOCAL_CLEAR',
+    },
+  ]);
+  mockedOAuthCredentialAdminService.revoke.mockResolvedValue({
+    ...credential,
+    provider: 'MICROSOFT',
+    accessTokenStored: false,
+    refreshTokenStored: false,
+    connected: false,
+    tokenExpiresAt: null,
+    providerRevokeSupported: false,
+    providerRevokeUnsupportedReason: 'No locally stored OAuth token to revoke',
+    providerRevokeMode: 'UNSUPPORTED',
+  });
+
+  renderPage();
+  await screen.findByText('MICROSOFT');
+
+  fireEvent.click(screen.getByRole('button', { name: 'Local Clear' }));
+
+  expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining("does not revoke the user's Entra sign-in sessions"));
+  await waitFor(() => {
+    expect(mockedOAuthCredentialAdminService.revoke).toHaveBeenCalledWith('credential-1');
+  });
+  await waitFor(() => {
+    const button = screen.getByRole('button', { name: 'Provider Revoke' }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  confirmSpy.mockRestore();
 });
 
 test('does not revoke OAuth token when confirmation is cancelled', async () => {
@@ -595,6 +657,7 @@ test('revokes OAuth token at the provider and replaces the row from the redacted
     providerRevokeSupported: false,
     providerRevokeUnsupportedReason:
       'Provider-side revoke requires a locally stored OAuth token; this credential row only references env-managed secrets',
+    providerRevokeMode: 'UNSUPPORTED',
   });
 
   renderPage();

--- a/ecm-frontend/src/pages/OAuthCredentialAdminPage.tsx
+++ b/ecm-frontend/src/pages/OAuthCredentialAdminPage.tsx
@@ -114,9 +114,9 @@ const matchesRevokeCapabilityFilter = (
 const revokeCapabilityFilterLabel = (filter: RevokeCapabilityFilter): string => {
   switch (filter) {
     case 'READY':
-      return 'Showing credentials where Provider Revoke is currently actionable.';
+      return 'Showing credentials where OAuth revoke/local-clear is currently actionable.';
     case 'BLOCKED':
-      return 'Showing credentials where Provider Revoke is blocked by backend capability metadata.';
+      return 'Showing credentials where OAuth revoke/local-clear is blocked by backend capability metadata.';
     case 'CUSTOM_ENDPOINT_GAP':
       return 'Showing CUSTOM credentials where provider-side revoke is blocked by a missing revoke endpoint.';
     case 'ENV_MANAGED_ONLY':
@@ -130,9 +130,9 @@ const revokeCapabilityFilterLabel = (filter: RevokeCapabilityFilter): string => 
 const revokeCapabilityFilterChipLabel = (filter: RevokeCapabilityFilter): string => {
   switch (filter) {
     case 'READY':
-      return 'Provider revoke ready';
+      return 'Revoke action ready';
     case 'BLOCKED':
-      return 'Provider revoke blocked';
+      return 'Revoke action blocked';
     case 'CUSTOM_ENDPOINT_GAP':
       return 'CUSTOM revoke gaps';
     case 'ENV_MANAGED_ONLY':
@@ -162,6 +162,25 @@ const statusChip = (label: string, active: boolean) => (
     size="small"
   />
 );
+
+const isLocalClearRevoke = (credential: OAuthCredentialInventoryItem): boolean => (
+  credential.providerRevokeMode === 'LOCAL_CLEAR'
+);
+
+const revokeActionLabel = (credential: OAuthCredentialInventoryItem): string => (
+  isLocalClearRevoke(credential) ? 'Local Clear' : 'Provider Revoke'
+);
+
+const revokeActionTooltip = (credential: OAuthCredentialInventoryItem): string => {
+  if (!credential.providerRevokeSupported) {
+    return credential.providerRevokeUnsupportedReason
+      ?? 'OAuth revoke/local-clear is not supported for this credential.';
+  }
+  if (isLocalClearRevoke(credential)) {
+    return 'Clears Athena-local Microsoft OAuth tokens only. Entra sessions remain until expiry or a separate Graph revokeSignInSessions action.';
+  }
+  return '';
+};
 
 const resolveErrorMessage = (err: unknown, fallback: string): string => {
   const responseMessage = (err as { response?: { data?: { message?: unknown } } })?.response?.data?.message;
@@ -359,9 +378,9 @@ const OAuthCredentialAdminPage: React.FC = () => {
   const emptyInventoryMessage = (() => {
     switch (revokeCapabilityFilter) {
       case 'READY':
-        return 'No OAuth credentials are currently ready for Provider Revoke.';
+        return 'No OAuth credentials are currently ready for revoke/local-clear action.';
       case 'BLOCKED':
-        return 'No OAuth credentials are currently blocked from Provider Revoke.';
+        return 'No OAuth credentials are currently blocked from revoke/local-clear action.';
       case 'CUSTOM_ENDPOINT_GAP':
         return 'No CUSTOM credentials currently need a revoke endpoint.';
       case 'ENV_MANAGED_ONLY':
@@ -417,8 +436,9 @@ const OAuthCredentialAdminPage: React.FC = () => {
   };
 
   const handleRevoke = async (credential: OAuthCredentialInventoryItem) => {
-    const confirmed = window.confirm(
-      `Revoke OAuth token at the provider for ${credential.ownerType} ${credential.ownerId}? This contacts Google to invalidate the token. The owner must reconnect afterwards. This is different from Require Reauth, which only clears Athena's local copy.`
+    const confirmed = window.confirm(isLocalClearRevoke(credential)
+      ? `Clear Athena-local Microsoft OAuth tokens for ${credential.ownerType} ${credential.ownerId}? Athena will stop using this credential immediately. This does not revoke the user's Entra sign-in sessions; those remain until expiry or a separate Microsoft Graph revokeSignInSessions action.`
+      : `Revoke OAuth token at the provider for ${credential.ownerType} ${credential.ownerId}? This contacts the provider to invalidate the token. The owner must reconnect afterwards. This is different from Require Reauth, which only clears Athena's local copy.`
     );
     if (!confirmed) {
       return;
@@ -429,7 +449,10 @@ const OAuthCredentialAdminPage: React.FC = () => {
       const updated = await oauthCredentialAdminService.revoke(credential.id);
       setCredentials((current) => current.map((item) => (item.id === updated.id ? updated : item)));
     } catch (err) {
-      setError(resolveErrorMessage(err, 'Failed to revoke OAuth token at the provider.'));
+      setError(resolveErrorMessage(err, isLocalClearRevoke(credential)
+        ? 'Failed to clear local Microsoft OAuth tokens.'
+        : 'Failed to revoke OAuth token at the provider.'
+      ));
       await loadCredentials(ownerType, provider, { preserveError: true });
     } finally {
       setRevokeCredentialId(null);
@@ -606,7 +629,7 @@ const OAuthCredentialAdminPage: React.FC = () => {
               aria-pressed={revokeCapabilityFilter === 'READY'}
               sx={{ minWidth: 210 }}
             >
-              Provider revoke ready ({providerRevokeReadyCount})
+              Revoke action ready ({providerRevokeReadyCount})
             </Button>
             <Button
               variant={revokeCapabilityFilter === 'BLOCKED' ? 'contained' : 'outlined'}
@@ -615,7 +638,7 @@ const OAuthCredentialAdminPage: React.FC = () => {
               aria-pressed={revokeCapabilityFilter === 'BLOCKED'}
               sx={{ minWidth: 220 }}
             >
-              Provider revoke blocked ({providerRevokeBlockedCount})
+              Revoke action blocked ({providerRevokeBlockedCount})
             </Button>
             <Button
               variant={revokeCapabilityFilter === 'CUSTOM_ENDPOINT_GAP' ? 'contained' : 'outlined'}
@@ -781,19 +804,14 @@ const OAuthCredentialAdminPage: React.FC = () => {
                             </Button>
                           )}
                           <Tooltip
-                            title={
-                              !credential.providerRevokeSupported
-                                ? (credential.providerRevokeUnsupportedReason
-                                  ?? 'Provider-side revoke is not supported for this credential.')
-                                : ''
-                            }
+                            title={revokeActionTooltip(credential)}
                           >
                             <span
                               data-testid={`provider-revoke-wrapper-${credential.id}`}
                               aria-label={
                                 !credential.providerRevokeSupported
                                   ? (credential.providerRevokeUnsupportedReason
-                                    ?? 'Provider-side revoke is not supported for this credential.')
+                                    ?? 'OAuth revoke/local-clear is not supported for this credential.')
                                   : undefined
                               }
                             >
@@ -809,7 +827,9 @@ const OAuthCredentialAdminPage: React.FC = () => {
                                   || !credential.providerRevokeSupported
                                 }
                               >
-                                {revokeCredentialId === credential.id ? 'Revoking...' : 'Provider Revoke'}
+                                {revokeCredentialId === credential.id
+                                  ? (isLocalClearRevoke(credential) ? 'Clearing...' : 'Revoking...')
+                                  : revokeActionLabel(credential)}
                               </Button>
                             </span>
                           </Tooltip>

--- a/ecm-frontend/src/services/oauthCredentialAdminService.test.ts
+++ b/ecm-frontend/src/services/oauthCredentialAdminService.test.ts
@@ -33,6 +33,7 @@ const credential: OAuthCredentialInventoryItem = {
   updatedAt: '2026-05-06T10:00:00Z',
   providerRevokeSupported: true,
   providerRevokeUnsupportedReason: null,
+  providerRevokeMode: 'PROVIDER_REVOKE',
 };
 
 describe('oauthCredentialAdminService', () => {
@@ -72,6 +73,16 @@ describe('oauthCredentialAdminService', () => {
         providerRevokeSupported: 'yes',
       },
     ]);
+
+    await expect(oauthCredentialAdminService.listCredentials()).rejects.toThrow(
+      OAUTH_CREDENTIAL_ADMIN_UNEXPECTED_RESPONSE_MESSAGE
+    );
+  });
+
+  test('rejects list items missing explicit revoke capability mode', async () => {
+    const withoutMode: Partial<OAuthCredentialInventoryItem> = { ...credential };
+    delete withoutMode.providerRevokeMode;
+    mockedApi.get.mockResolvedValueOnce([withoutMode]);
 
     await expect(oauthCredentialAdminService.listCredentials()).rejects.toThrow(
       OAUTH_CREDENTIAL_ADMIN_UNEXPECTED_RESPONSE_MESSAGE

--- a/ecm-frontend/src/services/oauthCredentialAdminService.ts
+++ b/ecm-frontend/src/services/oauthCredentialAdminService.ts
@@ -1,6 +1,7 @@
 import api from './api';
 
 export type OAuthProviderType = 'GOOGLE' | 'MICROSOFT' | 'CUSTOM' | string;
+export type OAuthRevokeCapabilityMode = 'PROVIDER_REVOKE' | 'LOCAL_CLEAR' | 'UNSUPPORTED';
 
 export interface OAuthCredentialInventoryItem {
   id: string;
@@ -20,6 +21,7 @@ export interface OAuthCredentialInventoryItem {
   updatedAt?: string | null;
   providerRevokeSupported: boolean;
   providerRevokeUnsupportedReason: string | null;
+  providerRevokeMode: OAuthRevokeCapabilityMode;
 }
 
 export interface OAuthCredentialInventoryFilters {
@@ -49,6 +51,10 @@ const isStringOrNullish = (value: unknown): value is string | null | undefined =
   value === null || value === undefined || typeof value === 'string'
 );
 
+const isOAuthRevokeCapabilityMode = (value: unknown): value is OAuthRevokeCapabilityMode => (
+  value === 'PROVIDER_REVOKE' || value === 'LOCAL_CLEAR' || value === 'UNSUPPORTED'
+);
+
 const isInventoryItem = (value: unknown): value is OAuthCredentialInventoryItem => {
   if (!isObject(value)) {
     return false;
@@ -69,7 +75,8 @@ const isInventoryItem = (value: unknown): value is OAuthCredentialInventoryItem 
     && typeof value.createdAt === 'string'
     && isStringOrNullish(value.updatedAt)
     && typeof value.providerRevokeSupported === 'boolean'
-    && isStringOrNullish(value.providerRevokeUnsupportedReason);
+    && isStringOrNullish(value.providerRevokeUnsupportedReason)
+    && isOAuthRevokeCapabilityMode(value.providerRevokeMode);
 };
 
 const assertInventoryItem = (value: unknown): OAuthCredentialInventoryItem => {


### PR DESCRIPTION
Summary

- Implements the #37 ratified Microsoft LOCAL-CLEAR semantics: Microsoft revoke clears Athena-local tokens and evicts the session without calling Entra, Graph, or provider endpoints.
- Adds explicit providerRevokeMode metadata (PROVIDER_REVOKE / LOCAL_CLEAR / UNSUPPORTED) across backend DTOs and frontend guards so Microsoft is not mislabeled as ordinary provider revoke.
- Keeps Google and configured CUSTOM provider-revoke behavior unchanged; env-managed/no-token rows remain unsupported.
- Marks the older Microsoft revoke discovery brief as superseded by the 2026-06-25 taskbook.

Test plan

- ./mvnw -q -Dtest=OAuthCredentialServiceTest,OAuthCredentialAdminServiceTest,OAuthCredentialAdminControllerSecurityTest test
- npm test -- --watchAll=false OAuthCredentialAdminPage oauthCredentialAdminService