### PR TITLE
feat(observability): scheduler-run observability for recurring @Scheduled jobs

### DIFF
--- a/ecm-core/pom.xml
+++ b/ecm-core/pom.xml
@@ -58,6 +58,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
         <dependency>

--- a/ecm-core/src/main/java/com/ecm/core/controller/SchedulerAdminController.java
+++ b/ecm-core/src/main/java/com/ecm/core/controller/SchedulerAdminController.java
@@ -1,0 +1,28 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.scheduler.SchedulerJobSnapshotDto;
+import com.ecm.core.scheduler.SchedulerObservabilityService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Scheduler Admin", description = "Recurring @Scheduled job run observability (read-only)")
+public class SchedulerAdminController {
+
+    private final SchedulerObservabilityService schedulerObservabilityService;
+
+    @GetMapping({"/api/admin/schedulers", "/api/v1/admin/schedulers"})
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "List recurring @Scheduled jobs with last-run / status / duration / next-run")
+    public ResponseEntity<List<SchedulerJobSnapshotDto>> getSchedulers() {
+        return ResponseEntity.ok(schedulerObservabilityService.getSnapshot());
+    }
+}

--- a/ecm-core/src/main/java/com/ecm/core/scheduler/ScheduledRunAspect.java
+++ b/ecm-core/src/main/java/com/ecm/core/scheduler/ScheduledRunAspect.java
@@ -1,0 +1,44 @@
+package com.ecm.core.scheduler;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+/**
+ * Captures every recurring {@code @Scheduled} invocation into the {@link SchedulerRunRegistry}
+ * (Day-2 scheduler-run observability). Observability-only — it does not change scheduler behaviour.
+ *
+ * <p>§3A.1: on failure it records the exception TYPE then <b>rethrows the original Throwable
+ * unchanged</b>, so Spring's scheduled-task error handling (and any retry cadence) is unaffected.
+ */
+@Aspect
+@Component
+public class ScheduledRunAspect {
+
+    private final SchedulerRunRegistry registry;
+
+    public ScheduledRunAspect(SchedulerRunRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Around("@annotation(org.springframework.scheduling.annotation.Scheduled)")
+    public Object recordScheduledRun(ProceedingJoinPoint joinPoint) throws Throwable {
+        String jobId = SchedulerJobIds.forJoinPoint(joinPoint);
+        long startNanos = System.nanoTime();
+        registry.recordStart(jobId);
+        try {
+            Object result = joinPoint.proceed();
+            registry.recordSuccess(jobId, elapsedMs(startNanos));
+            return result;
+        } catch (Throwable t) {
+            // Type only — never the message/stack (sensitive-data logging line).
+            registry.recordFailure(jobId, elapsedMs(startNanos), t.getClass().getSimpleName());
+            throw t;
+        }
+    }
+
+    private static long elapsedMs(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000L;
+    }
+}

--- a/ecm-core/src/main/java/com/ecm/core/scheduler/SchedulerJobIds.java
+++ b/ecm-core/src/main/java/com/ecm/core/scheduler/SchedulerJobIds.java
@@ -1,0 +1,53 @@
+package com.ecm.core.scheduler;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.aop.support.AopUtils;
+
+import java.lang.reflect.Method;
+
+/**
+ * Stable, proxy-safe job-id derivation (§3A.3). The same scheme is used by the aspect (run data)
+ * and the observability service (schedule / next-run via ScheduledTaskHolder) so the two JOIN on
+ * one id.
+ *
+ * <p>Form: {@code declaringClass#methodName}, taken from the UNWRAPPED target class (never a
+ * CGLIB / {@code $$SpringCGLIB$$} proxy name). Overloaded / same-named methods get a deterministic
+ * parameter-type suffix so they remain distinct.
+ */
+public final class SchedulerJobIds {
+
+    private SchedulerJobIds() {
+    }
+
+    public static String of(Class<?> targetClass, Method method) {
+        // forJoinPoint / the service already unwrap via AopUtils.getTargetClass; as belt-and-suspenders
+        // strip any residual Spring CGLIB marker (e.g. Foo$$SpringCGLIB$$0) to the real class FQN.
+        String className = targetClass.getName();
+        int cglibMarker = className.indexOf("$$");
+        if (cglibMarker > 0) {
+            className = className.substring(0, cglibMarker);
+        }
+        String base = className + "#" + method.getName();
+        if (method.getParameterCount() == 0) {
+            return base;
+        }
+        StringBuilder sb = new StringBuilder(base).append('(');
+        Class<?>[] params = method.getParameterTypes();
+        for (int i = 0; i < params.length; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append(params[i].getSimpleName());
+        }
+        return sb.append(')').toString();
+    }
+
+    public static String forJoinPoint(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Class<?> targetClass = joinPoint.getTarget() != null
+            ? AopUtils.getTargetClass(joinPoint.getTarget())
+            : signature.getDeclaringType();
+        return of(targetClass, signature.getMethod());
+    }
+}

--- a/ecm-core/src/main/java/com/ecm/core/scheduler/SchedulerJobSnapshotDto.java
+++ b/ecm-core/src/main/java/com/ecm/core/scheduler/SchedulerJobSnapshotDto.java
@@ -1,0 +1,24 @@
+package com.ecm.core.scheduler;
+
+import java.time.LocalDateTime;
+
+/**
+ * One row per registered recurring {@code @Scheduled} job (admin read-only observability).
+ *
+ * <p>§3A.2: {@code nextRunAt} is NULLABLE — it is populated only where the trigger semantics make it
+ * cleanly computable (cron, or fixedRate after a run); otherwise it is {@code null} and
+ * {@code scheduleDescription} (always non-null) carries the cron string / {@code fixedDelay=Nms} etc.
+ * The endpoint never fabricates a time.
+ */
+public record SchedulerJobSnapshotDto(
+    String jobId,
+    LocalDateTime lastRunAt,
+    String lastStatus,
+    Long lastDurationMs,
+    String lastErrorType,
+    long runCount,
+    long failCount,
+    LocalDateTime nextRunAt,
+    String scheduleDescription
+) {
+}

--- a/ecm-core/src/main/java/com/ecm/core/scheduler/SchedulerObservabilityService.java
+++ b/ecm-core/src/main/java/com/ecm/core/scheduler/SchedulerObservabilityService.java
@@ -1,0 +1,129 @@
+package com.ecm.core.scheduler;
+
+import org.springframework.aop.support.AopUtils;
+import org.springframework.scheduling.config.CronTask;
+import org.springframework.scheduling.config.FixedDelayTask;
+import org.springframework.scheduling.config.FixedRateTask;
+import org.springframework.scheduling.config.ScheduledTask;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
+import org.springframework.scheduling.config.Task;
+import org.springframework.scheduling.support.CronExpression;
+import org.springframework.scheduling.support.ScheduledMethodRunnable;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Joins the {@link SchedulerRunRegistry} (run data, from the aspect) with Spring's
+ * {@link ScheduledTaskHolder} (schedule + next-run) on the stable {@link SchedulerJobIds} id.
+ *
+ * <p>§3A.2: {@code nextRunAt} is computed only where well-defined (cron; fixedRate from the last
+ * run); fixedDelay → {@code null} (depends on completion). Any failure → {@code null} + a
+ * {@code scheduleDescription}; the method never throws.
+ */
+@Service
+public class SchedulerObservabilityService {
+
+    private final SchedulerRunRegistry registry;
+    private final ScheduledTaskHolder scheduledTaskHolder;
+
+    public SchedulerObservabilityService(SchedulerRunRegistry registry, ScheduledTaskHolder scheduledTaskHolder) {
+        this.registry = registry;
+        this.scheduledTaskHolder = scheduledTaskHolder;
+    }
+
+    public List<SchedulerJobSnapshotDto> getSnapshot() {
+        LocalDateTime now = LocalDateTime.now();
+        Map<String, SchedulerJobSnapshotDto> byId = new LinkedHashMap<>();
+
+        for (ScheduledTask scheduledTask : scheduledTaskHolder.getScheduledTasks()) {
+            ScheduleInfo info = describe(scheduledTask, now);
+            if (info == null) {
+                continue;
+            }
+            byId.put(info.jobId(), toDto(info.jobId(), registry.get(info.jobId()), info.nextRunAt(), info.description()));
+        }
+
+        // Defensive: surface any job that recorded a run but is not (or no longer) in the holder.
+        for (Map.Entry<String, SchedulerRunRegistry.RunRecord> e : registry.snapshot().entrySet()) {
+            byId.computeIfAbsent(e.getKey(), k -> toDto(k, e.getValue(), null, "unknown"));
+        }
+
+        List<SchedulerJobSnapshotDto> out = new ArrayList<>(byId.values());
+        out.sort(Comparator.comparing(SchedulerJobSnapshotDto::jobId));
+        return out;
+    }
+
+    private record ScheduleInfo(String jobId, LocalDateTime nextRunAt, String description) {
+    }
+
+    private ScheduleInfo describe(ScheduledTask scheduledTask, LocalDateTime now) {
+        try {
+            Task task = scheduledTask.getTask();
+            String jobId = jobIdFor(task.getRunnable());
+            if (jobId == null) {
+                return null;
+            }
+            if (task instanceof CronTask cronTask) {
+                return new ScheduleInfo(jobId, nextCron(cronTask.getExpression(), now), "cron: " + cronTask.getExpression());
+            }
+            if (task instanceof FixedRateTask fixedRateTask) {
+                long ms = fixedRateTask.getInterval();
+                SchedulerRunRegistry.RunRecord rec = registry.get(jobId);
+                LocalDateTime next = (rec != null && rec.lastRunAt() != null)
+                    ? rec.lastRunAt().plus(Duration.ofMillis(ms))
+                    : null;
+                return new ScheduleInfo(jobId, next, "fixedRate=" + ms + "ms");
+            }
+            if (task instanceof FixedDelayTask fixedDelayTask) {
+                // §3A.2: next depends on the previous completion → not cleanly computable → null.
+                return new ScheduleInfo(jobId, null, "fixedDelay=" + fixedDelayTask.getInterval() + "ms");
+            }
+            return new ScheduleInfo(jobId, null, task.getClass().getSimpleName());
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+
+    private static LocalDateTime nextCron(String expression, LocalDateTime now) {
+        try {
+            if (expression == null || !CronExpression.isValidExpression(expression)) {
+                return null;
+            }
+            return CronExpression.parse(expression).next(now);
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+
+    private static String jobIdFor(Runnable runnable) {
+        if (runnable instanceof ScheduledMethodRunnable smr) {
+            return SchedulerJobIds.of(AopUtils.getTargetClass(smr.getTarget()), smr.getMethod());
+        }
+        return null;
+    }
+
+    private static SchedulerJobSnapshotDto toDto(String jobId, SchedulerRunRegistry.RunRecord rec,
+                                                 LocalDateTime nextRunAt, String description) {
+        if (rec == null) {
+            return new SchedulerJobSnapshotDto(jobId, null, null, null, null, 0L, 0L, nextRunAt, description);
+        }
+        return new SchedulerJobSnapshotDto(
+            jobId,
+            rec.lastRunAt(),
+            rec.lastStatus() == null ? null : rec.lastStatus().name(),
+            rec.lastDurationMs(),
+            rec.lastErrorType(),
+            rec.runCount(),
+            rec.failCount(),
+            nextRunAt,
+            description
+        );
+    }
+}

--- a/ecm-core/src/main/java/com/ecm/core/scheduler/SchedulerRunRegistry.java
+++ b/ecm-core/src/main/java/com/ecm/core/scheduler/SchedulerRunRegistry.java
@@ -1,0 +1,74 @@
+package com.ecm.core.scheduler;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory, since-boot registry of recurring {@code @Scheduled} job runs (Day-2 scheduler-run
+ * observability, taskbook DEVELOPMENT_SCHEDULER_WORKER_OBSERVABILITY_TASKBOOK_20260625).
+ *
+ * <p>Records are kept per stable {@code jobId} (see {@link SchedulerJobIds}). Mutations go through
+ * {@link ConcurrentHashMap#compute} on an immutable {@link RunRecord} so updates are atomic and
+ * thread-safe; only the exception TYPE is stored (never a message/stack), per the sensitive-data
+ * logging line.
+ */
+@Component
+public class SchedulerRunRegistry {
+
+    public enum Status { RUNNING, SUCCESS, FAILED }
+
+    public record RunRecord(
+        LocalDateTime lastRunAt,
+        Status lastStatus,
+        Long lastDurationMs,
+        String lastErrorType,
+        long runCount,
+        long failCount
+    ) {}
+
+    private final Map<String, RunRecord> records = new ConcurrentHashMap<>();
+
+    public void recordStart(String jobId) {
+        records.compute(jobId, (k, old) -> new RunRecord(
+            LocalDateTime.now(),
+            Status.RUNNING,
+            old == null ? null : old.lastDurationMs(),
+            old == null ? null : old.lastErrorType(),
+            old == null ? 0L : old.runCount(),
+            old == null ? 0L : old.failCount()
+        ));
+    }
+
+    public void recordSuccess(String jobId, long durationMs) {
+        records.compute(jobId, (k, old) -> new RunRecord(
+            old == null ? LocalDateTime.now() : old.lastRunAt(),
+            Status.SUCCESS,
+            durationMs,
+            null,
+            (old == null ? 0L : old.runCount()) + 1,
+            old == null ? 0L : old.failCount()
+        ));
+    }
+
+    public void recordFailure(String jobId, long durationMs, String errorType) {
+        records.compute(jobId, (k, old) -> new RunRecord(
+            old == null ? LocalDateTime.now() : old.lastRunAt(),
+            Status.FAILED,
+            durationMs,
+            errorType,
+            (old == null ? 0L : old.runCount()) + 1,
+            (old == null ? 0L : old.failCount()) + 1
+        ));
+    }
+
+    public RunRecord get(String jobId) {
+        return records.get(jobId);
+    }
+
+    public Map<String, RunRecord> snapshot() {
+        return Map.copyOf(records);
+    }
+}

--- a/ecm-core/src/test/java/com/ecm/core/controller/SchedulerAdminControllerSecurityTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/SchedulerAdminControllerSecurityTest.java
@@ -1,0 +1,79 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.scheduler.SchedulerObservabilityService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SchedulerAdminController.class)
+@ContextConfiguration(classes = {
+    SchedulerAdminController.class,
+    RestExceptionHandler.class,
+    SchedulerAdminControllerSecurityTest.TestSecurityConfig.class
+})
+class SchedulerAdminControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SchedulerObservabilityService schedulerObservabilityService;
+
+    @Configuration
+    @EnableWebSecurity
+    @EnableMethodSecurity(prePostEnabled = true)
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/api/**").authenticated()
+                    .anyRequest().permitAll()
+                )
+                .httpBasic(basic -> {});
+            return http.build();
+        }
+    }
+
+    @Test
+    @DisplayName("unauthenticated GET /admin/schedulers returns 401")
+    void unauthenticatedReturns401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/schedulers"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("ROLE_USER cannot read schedulers")
+    void userCannotRead() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/schedulers"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("ROLE_ADMIN can read schedulers")
+    void adminCanRead() throws Exception {
+        when(schedulerObservabilityService.getSnapshot()).thenReturn(List.of());
+        mockMvc.perform(get("/api/v1/admin/schedulers"))
+            .andExpect(status().isOk());
+    }
+}

--- a/ecm-core/src/test/java/com/ecm/core/controller/SchedulerAdminControllerTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/SchedulerAdminControllerTest.java
@@ -1,0 +1,65 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.scheduler.SchedulerJobSnapshotDto;
+import com.ecm.core.scheduler.SchedulerObservabilityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class SchedulerAdminControllerTest {
+
+    private final SchedulerObservabilityService service = mock(SchedulerObservabilityService.class);
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new SchedulerAdminController(service)).build();
+    }
+
+    @Test
+    void returnsSchedulerSnapshotShape() throws Exception {
+        when(service.getSnapshot()).thenReturn(List.of(
+            new SchedulerJobSnapshotDto(
+                "com.ecm.core.service.TrashService#purgeOldTrashItems",
+                LocalDateTime.parse("2026-06-25T02:00:00"),
+                "SUCCESS",
+                1200L,
+                null,
+                5L,
+                0L,
+                LocalDateTime.parse("2026-06-26T02:00:00"),
+                "cron: 0 0 2 * * *"
+            ),
+            new SchedulerJobSnapshotDto(
+                "com.ecm.core.integration.mail.service.MailFetcherService#fetchAllAccounts",
+                LocalDateTime.parse("2026-06-25T10:00:00"),
+                "FAILED",
+                300L,
+                "MailConnectException",
+                40L,
+                3L,
+                null,
+                "fixedDelay=60000ms"
+            )
+        ));
+
+        mockMvc.perform(get("/api/v1/admin/schedulers"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].jobId").value("com.ecm.core.service.TrashService#purgeOldTrashItems"))
+            .andExpect(jsonPath("$[0].lastStatus").value("SUCCESS"))
+            .andExpect(jsonPath("$[0].scheduleDescription").value("cron: 0 0 2 * * *"))
+            .andExpect(jsonPath("$[1].lastStatus").value("FAILED"))
+            .andExpect(jsonPath("$[1].lastErrorType").value("MailConnectException"))
+            .andExpect(jsonPath("$[1].scheduleDescription").value("fixedDelay=60000ms"));
+    }
+}

--- a/ecm-core/src/test/java/com/ecm/core/scheduler/ScheduledRunObservabilityIntegrationTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/scheduler/ScheduledRunObservabilityIntegrationTest.java
@@ -1,0 +1,157 @@
+package com.ecm.core.scheduler;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Acceptance for §3A.1 (capture proven by a REAL scheduled tick, not a direct call; failure rethrows)
+ * and §3A.2 (next-run honesty). A real Spring scheduler fires the test {@code @Scheduled} methods; the
+ * aspect (via {@code @EnableAspectJAutoProxy}) records into the registry.
+ */
+@SpringJUnitConfig(ScheduledRunObservabilityIntegrationTest.Config.class)
+@DisplayName("Scheduler-run observability — real scheduled-tick capture (§3A.1) + next-run honesty (§3A.2)")
+class ScheduledRunObservabilityIntegrationTest {
+
+    static final List<Throwable> SCHEDULER_ERRORS = new CopyOnWriteArrayList<>();
+
+    @EnableScheduling
+    @EnableAspectJAutoProxy
+    @Configuration
+    static class Config {
+        @Bean SchedulerRunRegistry schedulerRunRegistry() {
+            return new SchedulerRunRegistry();
+        }
+
+        @Bean ScheduledRunAspect scheduledRunAspect(SchedulerRunRegistry registry) {
+            return new ScheduledRunAspect(registry);
+        }
+
+        @Bean SchedulerObservabilityService schedulerObservabilityService(SchedulerRunRegistry registry, ScheduledTaskHolder holder) {
+            return new SchedulerObservabilityService(registry, holder);
+        }
+
+        @Bean SucceedingJob succeedingJob() {
+            return new SucceedingJob();
+        }
+
+        @Bean FailingJob failingJob() {
+            return new FailingJob();
+        }
+
+        @Bean CronJob cronJob() {
+            return new CronJob();
+        }
+
+        @Bean TaskScheduler taskScheduler() {
+            ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+            scheduler.setPoolSize(3);
+            // Capture rethrown exceptions to prove the aspect did not swallow them.
+            scheduler.setErrorHandler(SCHEDULER_ERRORS::add);
+            scheduler.initialize();
+            return scheduler;
+        }
+    }
+
+    static class SucceedingJob {
+        @Scheduled(fixedDelay = 40)
+        public void run() {
+            // succeeds
+        }
+    }
+
+    static class FailingJob {
+        @Scheduled(fixedDelay = 40)
+        public void run() {
+            throw new IllegalStateException("boom-SENSITIVE-detail");
+        }
+    }
+
+    static class CronJob {
+        @Scheduled(cron = "0 0 3 * * *")
+        public void nightly() {
+            // computable next-run; not fired during the test
+        }
+    }
+
+    @Autowired SchedulerRunRegistry registry;
+    @Autowired SchedulerObservabilityService service;
+
+    @Test
+    @DisplayName("§3A.1: real scheduler tick captured (SUCCESS/FAILED, type-only) and failure rethrows to Spring's error handler")
+    void realTickCapturedAndRethrown() throws Exception {
+        String successId = SchedulerJobIds.of(SucceedingJob.class, SucceedingJob.class.getMethod("run"));
+        String failId = SchedulerJobIds.of(FailingJob.class, FailingJob.class.getMethod("run"));
+
+        awaitStatus(successId, SchedulerRunRegistry.Status.SUCCESS);
+        awaitStatus(failId, SchedulerRunRegistry.Status.FAILED);
+
+        SchedulerRunRegistry.RunRecord bad = registry.get(failId);
+        assertEquals("IllegalStateException", bad.lastErrorType(), "type only — class simple name");
+        assertFalse(bad.lastErrorType().contains("SENSITIVE"), "no exception message/detail recorded");
+        assertTrue(bad.failCount() >= 1);
+        assertNotNull(bad.lastDurationMs());
+        assertTrue(registry.get(successId).runCount() >= 1);
+
+        long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline
+            && SCHEDULER_ERRORS.stream().noneMatch(t -> t instanceof IllegalStateException)) {
+            Thread.sleep(50);
+        }
+        assertTrue(SCHEDULER_ERRORS.stream().anyMatch(t -> t instanceof IllegalStateException),
+            "aspect must rethrow so Spring's scheduled error handling sees the original exception unchanged");
+    }
+
+    @Test
+    @DisplayName("§3A.2: cron -> computed nextRunAt; fixedDelay -> null + scheduleDescription; never fabricated; service never throws")
+    void nextRunHonesty() throws Exception {
+        String successId = SchedulerJobIds.of(SucceedingJob.class, SucceedingJob.class.getMethod("run"));
+        awaitStatus(successId, SchedulerRunRegistry.Status.SUCCESS);
+
+        List<SchedulerJobSnapshotDto> snapshot = service.getSnapshot();
+        assertFalse(snapshot.isEmpty());
+        assertTrue(snapshot.stream().allMatch(s -> s.scheduleDescription() != null),
+            "scheduleDescription is always non-null");
+
+        SchedulerJobSnapshotDto cron = snapshot.stream()
+            .filter(s -> s.jobId().endsWith("#nightly")).findFirst().orElseThrow();
+        assertTrue(cron.scheduleDescription().startsWith("cron:"));
+        assertNotNull(cron.nextRunAt(), "cron next-run is cleanly computable");
+
+        SchedulerJobSnapshotDto fixedDelay = snapshot.stream()
+            .filter(s -> s.jobId().equals(successId)).findFirst().orElseThrow();
+        assertTrue(fixedDelay.scheduleDescription().startsWith("fixedDelay="));
+        assertNull(fixedDelay.nextRunAt(), "fixedDelay next-run is not fabricated");
+    }
+
+    private void awaitStatus(String jobId, SchedulerRunRegistry.Status expected) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline) {
+            SchedulerRunRegistry.RunRecord record = registry.get(jobId);
+            if (record != null && record.lastStatus() == expected && record.runCount() >= 1) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+        fail("job " + jobId + " did not reach " + expected + " via a real scheduled tick");
+    }
+}

--- a/ecm-core/src/test/java/com/ecm/core/scheduler/SchedulerJobIdsTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/scheduler/SchedulerJobIdsTest.java
@@ -1,0 +1,56 @@
+package com.ecm.core.scheduler;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * §3A.3: jobId is a stable {@code declaringClass#methodName} (no CGLIB / proxy class name), with a
+ * deterministic suffix so overloaded / same-named methods stay distinct.
+ */
+class SchedulerJobIdsTest {
+
+    static class Alpha {
+        public void run() {
+        }
+
+        public void task(String s) {
+        }
+
+        public void task(int i) {
+        }
+    }
+
+    static class Beta {
+        public void run() {
+        }
+    }
+
+    @Test
+    @DisplayName("stable declaringClass#methodName, no CGLIB marker")
+    void stableDeclaringClassMethodName() throws Exception {
+        String id = SchedulerJobIds.of(Alpha.class, Alpha.class.getMethod("run"));
+        assertEquals(Alpha.class.getName() + "#run", id);
+        assertFalse(id.contains("$$"), "must not carry a CGLIB/proxy marker");
+    }
+
+    @Test
+    @DisplayName("overloaded methods get distinct, deterministic ids")
+    void overloadsAreDistinctAndDeterministic() throws Exception {
+        String byString = SchedulerJobIds.of(Alpha.class, Alpha.class.getMethod("task", String.class));
+        String byInt = SchedulerJobIds.of(Alpha.class, Alpha.class.getMethod("task", int.class));
+        assertNotEquals(byString, byInt);
+        assertEquals(byString, SchedulerJobIds.of(Alpha.class, Alpha.class.getMethod("task", String.class)));
+    }
+
+    @Test
+    @DisplayName("same method name in different classes is distinct")
+    void sameMethodNameDifferentClassesDistinct() throws Exception {
+        assertNotEquals(
+            SchedulerJobIds.of(Alpha.class, Alpha.class.getMethod("run")),
+            SchedulerJobIds.of(Beta.class, Beta.class.getMethod("run")));
+    }
+}

--- a/ecm-frontend/src/components/admin/ScheduledJobsCard.test.tsx
+++ b/ecm-frontend/src/components/admin/ScheduledJobsCard.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ScheduledJobsCard, { SchedulerJobSnapshot } from './ScheduledJobsCard';
+import apiService from '../../services/api';
+
+jest.mock('../../services/api', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+jest.mock('react-toastify', () => ({ toast: { warn: jest.fn() } }));
+
+const mockedGet = apiService.get as jest.Mock;
+
+describe('ScheduledJobsCard', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders one row per scheduled job with status and schedule', async () => {
+    const rows: SchedulerJobSnapshot[] = [
+      {
+        jobId: 'com.ecm.core.service.TrashService#purgeOldTrashItems',
+        lastRunAt: '2026-06-25T02:00:00',
+        lastStatus: 'SUCCESS',
+        lastDurationMs: 1200,
+        lastErrorType: null,
+        runCount: 5,
+        failCount: 0,
+        nextRunAt: '2026-06-26T02:00:00',
+        scheduleDescription: 'cron: 0 0 2 * * *',
+      },
+      {
+        jobId: 'com.ecm.core.integration.mail.service.MailFetcherService#fetchAllAccounts',
+        lastRunAt: '2026-06-25T10:00:00',
+        lastStatus: 'FAILED',
+        lastDurationMs: 300,
+        lastErrorType: 'MailConnectException',
+        runCount: 40,
+        failCount: 3,
+        nextRunAt: null,
+        scheduleDescription: 'fixedDelay=60000ms',
+      },
+    ];
+    mockedGet.mockResolvedValueOnce(rows);
+
+    render(<ScheduledJobsCard />);
+
+    expect(await screen.findByText(/TrashService#purgeOldTrashItems/)).toBeTruthy();
+    expect(screen.getByText('SUCCESS')).toBeTruthy();
+    expect(screen.getByText('FAILED')).toBeTruthy();
+    expect(screen.getByText('MailConnectException')).toBeTruthy();
+    // a fixedDelay job (nextRunAt == null) shows the scheduleDescription in the Next-run column
+    expect(screen.getByText('fixedDelay=60000ms')).toBeTruthy();
+  });
+
+  it('isolates a fetch failure: shows a warning and does not render the table or crash', async () => {
+    mockedGet.mockRejectedValueOnce(new Error('boom'));
+
+    render(<ScheduledJobsCard />);
+
+    expect(await screen.findByText(/unavailable right now/i)).toBeTruthy();
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+});

--- a/ecm-frontend/src/components/admin/ScheduledJobsCard.tsx
+++ b/ecm-frontend/src/components/admin/ScheduledJobsCard.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { toast } from 'react-toastify';
+import apiService from '../../services/api';
+
+export interface SchedulerJobSnapshot {
+  jobId: string;
+  lastRunAt: string | null;
+  lastStatus: 'SUCCESS' | 'FAILED' | 'RUNNING' | null;
+  lastDurationMs: number | null;
+  lastErrorType: string | null;
+  runCount: number;
+  failCount: number;
+  nextRunAt: string | null;
+  scheduleDescription: string;
+}
+
+const statusColor = (
+  status: SchedulerJobSnapshot['lastStatus'],
+): 'success' | 'error' | 'info' | 'default' => {
+  switch (status) {
+    case 'SUCCESS':
+      return 'success';
+    case 'FAILED':
+      return 'error';
+    case 'RUNNING':
+      return 'info';
+    default:
+      return 'default';
+  }
+};
+
+const fmt = (iso: string | null): string => (iso ? new Date(iso).toLocaleString() : '—');
+
+const shortJob = (jobId: string): string => {
+  const hash = jobId.indexOf('#');
+  if (hash < 0) {
+    return jobId;
+  }
+  const className = jobId.substring(0, hash);
+  const simpleName = className.substring(className.lastIndexOf('.') + 1);
+  return simpleName + jobId.substring(hash);
+};
+
+/**
+ * Read-only "Scheduled Jobs" card (Day-2 scheduler-run observability). Fetches the admin scheduler
+ * snapshot independently and is FAILURE-ISOLATED: a fetch error shows a local warning and a toast,
+ * it never breaks the surrounding AdminDashboard panels. Observability only — no trigger/cancel.
+ */
+const ScheduledJobsCard: React.FC = () => {
+  const [jobs, setJobs] = useState<SchedulerJobSnapshot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      setLoading(true);
+      setFailed(false);
+      try {
+        const data = await apiService.get<SchedulerJobSnapshot[]>('/admin/schedulers');
+        if (active) {
+          setJobs(Array.isArray(data) ? data : []);
+        }
+      } catch {
+        if (active) {
+          setFailed(true);
+          toast.warn('Failed to load scheduled-job status');
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Scheduled Jobs
+        </Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          Read-only last-run / next-run status for recurring @Scheduled jobs (since boot). Observability only — no trigger or cancel.
+        </Typography>
+        {loading && (
+          <Box py={2} display="flex" justifyContent="center">
+            <CircularProgress size={24} />
+          </Box>
+        )}
+        {!loading && failed && (
+          <Alert severity="warning">Scheduled-job status is unavailable right now.</Alert>
+        )}
+        {!loading && !failed && (
+          <TableContainer>
+            <Table size="small" aria-label="scheduled jobs">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Job</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell>Last run</TableCell>
+                  <TableCell>Next run</TableCell>
+                  <TableCell>Duration</TableCell>
+                  <TableCell>Last error</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {jobs.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={6}>No scheduled jobs registered.</TableCell>
+                  </TableRow>
+                )}
+                {jobs.map((job) => (
+                  <TableRow key={job.jobId}>
+                    <TableCell title={job.jobId}>{shortJob(job.jobId)}</TableCell>
+                    <TableCell>
+                      <Chip size="small" label={job.lastStatus ?? 'NEVER'} color={statusColor(job.lastStatus)} />
+                    </TableCell>
+                    <TableCell>{fmt(job.lastRunAt)}</TableCell>
+                    <TableCell>{job.nextRunAt ? fmt(job.nextRunAt) : job.scheduleDescription}</TableCell>
+                    <TableCell>{job.lastDurationMs != null ? `${job.lastDurationMs} ms` : '—'}</TableCell>
+                    <TableCell>{job.lastErrorType ?? '—'}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ScheduledJobsCard;

--- a/ecm-frontend/src/pages/AdminDashboard.tsx
+++ b/ecm-frontend/src/pages/AdminDashboard.tsx
@@ -70,6 +70,7 @@ import {
 } from '@mui/icons-material';
 import { format } from 'date-fns';
 import apiService from '../services/api';
+import ScheduledJobsCard from '../components/admin/ScheduledJobsCard';
 import { toast } from 'react-toastify';
 import userGroupService, { Group } from 'services/userGroupService';
 import savedSearchService, { SavedSearch } from 'services/savedSearchService';
@@ -2563,6 +2564,10 @@ const AdminDashboard: React.FC = () => {
             />
           </Grid>
         </Grid>
+
+        <Box mb={3}>
+          <ScheduledJobsCard />
+        </Box>
 
         <Paper sx={{ p: 2, mb: 3 }}>
           <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>


### PR DESCRIPTION
## Summary
Day-2 of the Scheduler/Worker observability line (taskbook #40, ratified candidate #1 + §6 + the §3A guards). Read-only run status for the ~18 recurring `@Scheduled` jobs — the blind spot from the Day-1 gap audit.

## Added
`SchedulerRunRegistry` (in-memory, since-boot) + `ScheduledRunAspect` (`@Around @Scheduled`) → `SchedulerObservabilityService` (joins runs with `ScheduledTaskHolder`) → `SchedulerAdminController` `GET /api/(v1/)admin/schedulers` (admin-only) → AdminDashboard "Scheduled Jobs" card. **Adds `spring-boot-starter-aop`** — the prerequisite for the ratified `@Around` aspect (was absent; no existing `@Aspect`). Flag if you'd rather a non-AspectJ TaskScheduler-decorator capture.

## §3A guards (acceptance) — how each is proven
- **§3A.1 (real tick + rethrow):** `ScheduledRunObservabilityIntegrationTest` boots a real `@EnableScheduling` + `@EnableAspectJAutoProxy` context with actual `@Scheduled(fixedDelay=40)` success/failing beans; polls the registry for SUCCESS/FAILED from the **real scheduler firing** (not a direct call); a custom `TaskScheduler` `ErrorHandler` captures the rethrown `IllegalStateException` → proves rethrow-unchanged. Type-only asserted (`!contains("SENSITIVE")`).
- **§3A.2 (no false precision):** `nextRunAt` computed only for cron + fixedRate; **fixedDelay → null** + non-null `scheduleDescription`; wrapped → never throws / never fabricates. Asserted (cron computed; fixedDelay null).
- **§3A.3 (stable, proxy-safe jobId):** `SchedulerJobIds` unwraps CGLIB (`AopUtils.getTargetClass` + strip `$$`) → `declaringClass#methodName` + param-type suffix for overloads; the **same** helper feeds the aspect and the service so run + schedule JOIN. Unit + integration tests prove it.

## Boundaries (§4)
Observability-only (GET-only, no trigger/cancel/pause); type-only errors; no scheduler-logic change; failure-isolated dashboard card; the 6 governance domains / quota / storage / logging untouched.

## Verification
Local Maven unavailable on this box → CI is the compile/test gate; the integration test (a real scheduled tick) is load-bearing. I (Claude) built this; reviewed each §3A guard against the code before opening — owner reviews/merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)