### PR TITLE
feat(observability): queue backlog observability (OCR / mail / transfer)

### DIFF
--- a/ecm-core/src/main/java/com/ecm/core/controller/QueueBacklogAdminController.java
+++ b/ecm-core/src/main/java/com/ecm/core/controller/QueueBacklogAdminController.java
@@ -1,0 +1,26 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.queuebacklog.QueueBacklogObservabilityService;
+import com.ecm.core.queuebacklog.QueueBacklogSummaryDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Queue Backlog Admin", description = "Read-only OCR / mail / transfer queue backlog observability")
+public class QueueBacklogAdminController {
+
+    private final QueueBacklogObservabilityService queueBacklogObservabilityService;
+
+    @GetMapping({"/api/admin/queue-backlog", "/api/v1/admin/queue-backlog"})
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "OCR depth/oldest, mail fetch-health, and transfer pending/running/failed/oldest/stuck")
+    public ResponseEntity<QueueBacklogSummaryDto> getQueueBacklog() {
+        return ResponseEntity.ok(queueBacklogObservabilityService.getSummary());
+    }
+}

--- a/ecm-core/src/main/java/com/ecm/core/ocr/OcrQueueService.java
+++ b/ecm-core/src/main/java/com/ecm/core/ocr/OcrQueueService.java
@@ -464,6 +464,39 @@ public class OcrQueueService {
         );
     }
 
+    /**
+     * Read-only backlog snapshot for queue-backlog observability (§5A: cheap reads only).
+     * Redis backend → {@code scheduledCount()} (ZCARD, O(1)) + {@code peek(1)} for the oldest item's age
+     * past its scheduled time; in-memory backend → the queued-jobs size (oldest age not tracked).
+     * Never throws — a Redis failure reports {@code available=false}. Does NOT touch OCR failed/running
+     * (those would require an unindexed {@code Document.metadata} scan, deliberately deferred).
+     */
+    public OcrBacklogSnapshot getBacklogSnapshot() {
+        try {
+            if (useRedisBackend()) {
+                RedisScheduledQueueStore store = redisStore();
+                long depth = store.scheduledCount();
+                Long oldestPendingAgeSeconds = null;
+                List<RedisScheduledQueueStore.Entry> head = store.peek(1);
+                if (!head.isEmpty() && head.get(0) != null && head.get(0).nextAttemptAt() != null) {
+                    long ageMs = Instant.now().toEpochMilli() - head.get(0).nextAttemptAt().toEpochMilli();
+                    oldestPendingAgeSeconds = Math.max(0L, ageMs / 1000L);
+                }
+                return new OcrBacklogSnapshot(true, depth, oldestPendingAgeSeconds);
+            }
+            return new OcrBacklogSnapshot(true, queuedJobs.size(), null);
+        } catch (RuntimeException ex) {
+            return new OcrBacklogSnapshot(false, 0L, null);
+        }
+    }
+
+    public record OcrBacklogSnapshot(
+        boolean available,
+        long pendingDepth,
+        Long oldestPendingAgeSeconds
+    ) {
+    }
+
     public record OcrQueueStatus(
         UUID documentId,
         String ocrStatus,

--- a/ecm-core/src/main/java/com/ecm/core/queuebacklog/QueueBacklogObservabilityService.java
+++ b/ecm-core/src/main/java/com/ecm/core/queuebacklog/QueueBacklogObservabilityService.java
@@ -1,0 +1,112 @@
+package com.ecm.core.queuebacklog;
+
+import com.ecm.core.entity.ReplicationJob;
+import com.ecm.core.integration.mail.model.MailAccount;
+import com.ecm.core.integration.mail.repository.MailAccountRepository;
+import com.ecm.core.ocr.OcrQueueService;
+import com.ecm.core.queuebacklog.QueueBacklogSummaryDto.MailBacklog;
+import com.ecm.core.queuebacklog.QueueBacklogSummaryDto.OcrBacklog;
+import com.ecm.core.queuebacklog.QueueBacklogSummaryDto.TransferBacklog;
+import com.ecm.core.repository.ReplicationJobRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Aggregates the read-only "Queue Backlog" snapshot from the three subsystems (OCR / mail / transfer).
+ *
+ * <p><b>§5A index-first:</b> transfer uses index-backed {@code countByStatus} / oldest / stuck (status +
+ * created_at are indexed); mail uses the same account-level fetch-health semantics as runtime metrics without
+ * querying {@code mail_processed_messages}; OCR is O(1) Redis ops. Each source is wrapped so a failure yields
+ * {@code available=false} instead of throwing — one bad source never sinks the whole card.
+ */
+@Service
+public class QueueBacklogObservabilityService {
+
+    private final OcrQueueService ocrQueueService;
+    private final MailAccountRepository mailAccountRepository;
+    private final ReplicationJobRepository replicationJobRepository;
+
+    @Value("${ecm.queue-backlog.transfer-stuck-minutes:60}")
+    private long transferStuckMinutes;
+
+    public QueueBacklogObservabilityService(OcrQueueService ocrQueueService,
+                                            MailAccountRepository mailAccountRepository,
+                                            ReplicationJobRepository replicationJobRepository) {
+        this.ocrQueueService = ocrQueueService;
+        this.mailAccountRepository = mailAccountRepository;
+        this.replicationJobRepository = replicationJobRepository;
+    }
+
+    public QueueBacklogSummaryDto getSummary() {
+        return new QueueBacklogSummaryDto(ocrBacklog(), mailBacklog(), transferBacklog());
+    }
+
+    private OcrBacklog ocrBacklog() {
+        try {
+            OcrQueueService.OcrBacklogSnapshot s = ocrQueueService.getBacklogSnapshot();
+            return new OcrBacklog(s.available(), s.pendingDepth(), s.oldestPendingAgeSeconds());
+        } catch (RuntimeException ex) {
+            return new OcrBacklog(false, 0L, null);
+        }
+    }
+
+    private MailBacklog mailBacklog() {
+        try {
+            LocalDateTime threshold = LocalDateTime.now().minusMinutes(60);
+            List<MailAccount> windowAccounts = mailAccountRepository.findAll().stream()
+                .filter(account -> account.getLastFetchAt() != null && !account.getLastFetchAt().isBefore(threshold))
+                .toList();
+
+            long attempts = windowAccounts.size();
+            long successes = windowAccounts.stream()
+                .filter(account -> "SUCCESS".equalsIgnoreCase(account.getLastFetchStatus()))
+                .count();
+            long errors = windowAccounts.stream()
+                .filter(account -> "ERROR".equalsIgnoreCase(account.getLastFetchStatus()))
+                .count();
+            double errorRate = attempts > 0 ? (double) errors / attempts : 0.0d;
+            LocalDateTime lastSuccessAt = windowAccounts.stream()
+                .filter(account -> "SUCCESS".equalsIgnoreCase(account.getLastFetchStatus()))
+                .map(MailAccount::getLastFetchAt)
+                .filter(Objects::nonNull)
+                .max(LocalDateTime::compareTo)
+                .orElse(null);
+            String status = attempts == 0
+                ? "UNKNOWN"
+                : errors == 0
+                    ? "HEALTHY"
+                    : successes == 0
+                        ? "DOWN"
+                        : "DEGRADED";
+            return new MailBacklog(true, lastSuccessAt, errorRate, errors, status);
+        } catch (RuntimeException ex) {
+            return new MailBacklog(false, null, 0.0d, 0L, null);
+        }
+    }
+
+    private TransferBacklog transferBacklog() {
+        try {
+            long pending = replicationJobRepository.countByStatus(ReplicationJob.ReplicationJobStatus.PENDING);
+            long running = replicationJobRepository.countByStatus(ReplicationJob.ReplicationJobStatus.RUNNING);
+            long failed = replicationJobRepository.countByStatus(ReplicationJob.ReplicationJobStatus.FAILED);
+            Long oldestPendingAgeSeconds = replicationJobRepository
+                .findFirstByStatusOrderByCreatedAtAsc(ReplicationJob.ReplicationJobStatus.PENDING)
+                .map(ReplicationJob::getCreatedAt)
+                .filter(Objects::nonNull)
+                .map(createdAt -> Math.max(0L, Duration.between(createdAt, LocalDateTime.now()).getSeconds()))
+                .orElse(null);
+            long stuckRunning = replicationJobRepository.countByStatusAndStartedAtBefore(
+                ReplicationJob.ReplicationJobStatus.RUNNING,
+                LocalDateTime.now().minusMinutes(transferStuckMinutes));
+            return new TransferBacklog(true, pending, running, failed, oldestPendingAgeSeconds,
+                stuckRunning, transferStuckMinutes);
+        } catch (RuntimeException ex) {
+            return new TransferBacklog(false, 0L, 0L, 0L, null, 0L, transferStuckMinutes);
+        }
+    }
+}

--- a/ecm-core/src/main/java/com/ecm/core/queuebacklog/QueueBacklogSummaryDto.java
+++ b/ecm-core/src/main/java/com/ecm/core/queuebacklog/QueueBacklogSummaryDto.java
@@ -1,0 +1,49 @@
+package com.ecm.core.queuebacklog;
+
+import java.time.LocalDateTime;
+
+/**
+ * Read-only "Queue Backlog" snapshot across the three subsystems (Day-2 queue backlog observability,
+ * taskbook DEVELOPMENT_QUEUE_BACKLOG_OBSERVABILITY_TASKBOOK_20260626). Observability-only; every signal
+ * is a cheap, index-backed / O(1) read (§5A), and any unavailable source reports {@code available=false}
+ * rather than throwing.
+ *
+ * <ul>
+ *   <li><b>OCR</b> — Redis depth + oldest (the deferred failed/running would need an unindexed scan).</li>
+ *   <li><b>Mail</b> — account-level fetch-health (same status semantics as runtime metrics; IMAP pull has no local queue depth).</li>
+ *   <li><b>Transfer</b> — full backlog via index-backed {@code countByStatus} / oldest / stuck.</li>
+ * </ul>
+ */
+public record QueueBacklogSummaryDto(
+    OcrBacklog ocr,
+    MailBacklog mail,
+    TransferBacklog transfer
+) {
+
+    /** OCR queue (Redis ZSET, or in-memory fallback). {@code oldestPendingAgeSeconds} = age past the oldest item's scheduled time. */
+    public record OcrBacklog(
+        boolean available,
+        long pendingDepth,
+        Long oldestPendingAgeSeconds
+    ) {}
+
+    /** Mail fetch-health (NOT a queue — IMAP is pull-based). Uses the account-level last-fetch window. */
+    public record MailBacklog(
+        boolean available,
+        LocalDateTime lastSuccessAt,
+        double errorRate,
+        long errors,
+        String status
+    ) {}
+
+    /** Transfer replication backlog (DB, index-backed). {@code stuckRunningCount} = RUNNING older than {@code stuckThresholdMinutes}. */
+    public record TransferBacklog(
+        boolean available,
+        long pendingCount,
+        long runningCount,
+        long failedCount,
+        Long oldestPendingAgeSeconds,
+        long stuckRunningCount,
+        long stuckThresholdMinutes
+    ) {}
+}

--- a/ecm-core/src/main/java/com/ecm/core/repository/ReplicationJobRepository.java
+++ b/ecm-core/src/main/java/com/ecm/core/repository/ReplicationJobRepository.java
@@ -9,12 +9,20 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface ReplicationJobRepository extends JpaRepository<ReplicationJob, UUID> {
 
     Page<ReplicationJob> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    // Queue-backlog observability (read-only, index-backed via idx_replication_job_status / _created_at).
+    long countByStatus(ReplicationJob.ReplicationJobStatus status);
+
+    Optional<ReplicationJob> findFirstByStatusOrderByCreatedAtAsc(ReplicationJob.ReplicationJobStatus status);
+
+    long countByStatusAndStartedAtBefore(ReplicationJob.ReplicationJobStatus status, LocalDateTime startedAt);
 
     List<ReplicationJob> findByStatusAndScheduledForLessThanEqual(ReplicationJob.ReplicationJobStatus status, LocalDateTime scheduledFor);
 

--- a/ecm-core/src/test/java/com/ecm/core/controller/QueueBacklogAdminControllerSecurityTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/QueueBacklogAdminControllerSecurityTest.java
@@ -1,0 +1,85 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.queuebacklog.QueueBacklogObservabilityService;
+import com.ecm.core.queuebacklog.QueueBacklogSummaryDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = QueueBacklogAdminController.class)
+@ContextConfiguration(classes = {
+    QueueBacklogAdminController.class,
+    RestExceptionHandler.class,
+    QueueBacklogAdminControllerSecurityTest.TestSecurityConfig.class
+})
+class QueueBacklogAdminControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private QueueBacklogObservabilityService queueBacklogObservabilityService;
+
+    @Configuration
+    @EnableWebSecurity
+    @EnableMethodSecurity(prePostEnabled = true)
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/api/**").authenticated()
+                    .anyRequest().permitAll()
+                )
+                .httpBasic(basic -> {});
+            return http.build();
+        }
+    }
+
+    private static QueueBacklogSummaryDto sampleSummary() {
+        return new QueueBacklogSummaryDto(
+            new QueueBacklogSummaryDto.OcrBacklog(true, 0L, null),
+            new QueueBacklogSummaryDto.MailBacklog(true, null, 0.0d, 0L, "OK"),
+            new QueueBacklogSummaryDto.TransferBacklog(true, 0L, 0L, 0L, null, 0L, 60L));
+    }
+
+    @Test
+    @DisplayName("unauthenticated GET /admin/queue-backlog returns 401")
+    void unauthenticatedReturns401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/queue-backlog"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("ROLE_USER cannot read the queue backlog")
+    void userCannotRead() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/queue-backlog"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("ROLE_ADMIN can read the queue backlog")
+    void adminCanRead() throws Exception {
+        when(queueBacklogObservabilityService.getSummary()).thenReturn(sampleSummary());
+        mockMvc.perform(get("/api/v1/admin/queue-backlog"))
+            .andExpect(status().isOk());
+    }
+}

--- a/ecm-core/src/test/java/com/ecm/core/controller/QueueBacklogAdminControllerTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/QueueBacklogAdminControllerTest.java
@@ -1,0 +1,48 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.queuebacklog.QueueBacklogObservabilityService;
+import com.ecm.core.queuebacklog.QueueBacklogSummaryDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class QueueBacklogAdminControllerTest {
+
+    private final QueueBacklogObservabilityService service = mock(QueueBacklogObservabilityService.class);
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new QueueBacklogAdminController(service)).build();
+    }
+
+    @Test
+    void returnsQueueBacklogShape() throws Exception {
+        when(service.getSummary()).thenReturn(new QueueBacklogSummaryDto(
+            new QueueBacklogSummaryDto.OcrBacklog(true, 7L, 120L),
+            new QueueBacklogSummaryDto.MailBacklog(true, LocalDateTime.parse("2026-06-26T09:00:00"), 0.2d, 2L, "DEGRADED"),
+            new QueueBacklogSummaryDto.TransferBacklog(true, 3L, 1L, 2L, 1800L, 1L, 60L)));
+
+        mockMvc.perform(get("/api/v1/admin/queue-backlog"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.ocr.available").value(true))
+            .andExpect(jsonPath("$.ocr.pendingDepth").value(7))
+            .andExpect(jsonPath("$.ocr.oldestPendingAgeSeconds").value(120))
+            .andExpect(jsonPath("$.mail.errorRate").value(0.2))
+            .andExpect(jsonPath("$.mail.status").value("DEGRADED"))
+            .andExpect(jsonPath("$.transfer.pendingCount").value(3))
+            .andExpect(jsonPath("$.transfer.runningCount").value(1))
+            .andExpect(jsonPath("$.transfer.failedCount").value(2))
+            .andExpect(jsonPath("$.transfer.stuckRunningCount").value(1))
+            .andExpect(jsonPath("$.transfer.stuckThresholdMinutes").value(60));
+    }
+}

--- a/ecm-core/src/test/java/com/ecm/core/queuebacklog/QueueBacklogObservabilityServiceTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/queuebacklog/QueueBacklogObservabilityServiceTest.java
@@ -1,0 +1,107 @@
+package com.ecm.core.queuebacklog;
+
+import com.ecm.core.entity.ReplicationJob;
+import com.ecm.core.integration.mail.model.MailAccount;
+import com.ecm.core.integration.mail.repository.MailAccountRepository;
+import com.ecm.core.ocr.OcrQueueService;
+import com.ecm.core.repository.ReplicationJobRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class QueueBacklogObservabilityServiceTest {
+
+    private final OcrQueueService ocrQueueService = mock(OcrQueueService.class);
+    private final MailAccountRepository mailAccountRepository = mock(MailAccountRepository.class);
+    private final ReplicationJobRepository replicationJobRepository = mock(ReplicationJobRepository.class);
+
+    private QueueBacklogObservabilityService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new QueueBacklogObservabilityService(ocrQueueService, mailAccountRepository, replicationJobRepository);
+        ReflectionTestUtils.setField(service, "transferStuckMinutes", 60L);
+    }
+
+    private static MailAccount account(String status, LocalDateTime lastFetchAt) {
+        MailAccount account = new MailAccount();
+        account.setLastFetchStatus(status);
+        account.setLastFetchAt(lastFetchAt);
+        return account;
+    }
+
+    @Test
+    @DisplayName("aggregates OCR depth/oldest, mail fetch-health, and transfer counts/oldest/stuck")
+    void aggregatesAllThree() {
+        when(ocrQueueService.getBacklogSnapshot())
+            .thenReturn(new OcrQueueService.OcrBacklogSnapshot(true, 7L, 120L));
+        LocalDateTime lastSuccess = LocalDateTime.now().minusMinutes(5);
+        when(mailAccountRepository.findAll()).thenReturn(List.of(
+            account("SUCCESS", lastSuccess),
+            account("ERROR", LocalDateTime.now().minusMinutes(3)),
+            account("ERROR", LocalDateTime.now().minusMinutes(2)),
+            account("SUCCESS", LocalDateTime.now().minusMinutes(70))));
+
+        when(replicationJobRepository.countByStatus(ReplicationJob.ReplicationJobStatus.PENDING)).thenReturn(3L);
+        when(replicationJobRepository.countByStatus(ReplicationJob.ReplicationJobStatus.RUNNING)).thenReturn(1L);
+        when(replicationJobRepository.countByStatus(ReplicationJob.ReplicationJobStatus.FAILED)).thenReturn(2L);
+        ReplicationJob oldest = new ReplicationJob();
+        oldest.setStatus(ReplicationJob.ReplicationJobStatus.PENDING);
+        oldest.setCreatedAt(LocalDateTime.now().minusMinutes(30));
+        when(replicationJobRepository.findFirstByStatusOrderByCreatedAtAsc(ReplicationJob.ReplicationJobStatus.PENDING))
+            .thenReturn(Optional.of(oldest));
+        when(replicationJobRepository.countByStatusAndStartedAtBefore(eq(ReplicationJob.ReplicationJobStatus.RUNNING), any()))
+            .thenReturn(1L);
+
+        QueueBacklogSummaryDto dto = service.getSummary();
+
+        assertThat(dto.ocr().available()).isTrue();
+        assertThat(dto.ocr().pendingDepth()).isEqualTo(7L);
+        assertThat(dto.ocr().oldestPendingAgeSeconds()).isEqualTo(120L);
+
+        assertThat(dto.mail().available()).isTrue();
+        assertThat(dto.mail().errors()).isEqualTo(2L);
+        assertThat(dto.mail().errorRate()).isEqualTo(2.0d / 3.0d);
+        assertThat(dto.mail().status()).isEqualTo("DEGRADED");
+        assertThat(dto.mail().lastSuccessAt()).isEqualTo(lastSuccess);
+
+        assertThat(dto.transfer().available()).isTrue();
+        assertThat(dto.transfer().pendingCount()).isEqualTo(3L);
+        assertThat(dto.transfer().runningCount()).isEqualTo(1L);
+        assertThat(dto.transfer().failedCount()).isEqualTo(2L);
+        assertThat(dto.transfer().stuckRunningCount()).isEqualTo(1L);
+        assertThat(dto.transfer().stuckThresholdMinutes()).isEqualTo(60L);
+        // oldest PENDING createdAt was ~30m ago.
+        assertThat(dto.transfer().oldestPendingAgeSeconds()).isBetween(1700L, 1900L);
+    }
+
+    @Test
+    @DisplayName("a failing source reports available=false and the service never throws")
+    void failingSourceIsIsolated() {
+        when(ocrQueueService.getBacklogSnapshot()).thenThrow(new RuntimeException("redis down"));
+        when(mailAccountRepository.findAll()).thenThrow(new RuntimeException("mail down"));
+        when(replicationJobRepository.countByStatus(any())).thenThrow(new RuntimeException("db down"));
+
+        QueueBacklogSummaryDto dto = service.getSummary();
+
+        assertThat(dto.ocr().available()).isFalse();
+        assertThat(dto.ocr().pendingDepth()).isZero();
+        assertThat(dto.mail().available()).isFalse();
+        assertThat(dto.mail().lastSuccessAt()).isNull();
+        assertThat(dto.transfer().available()).isFalse();
+        assertThat(dto.transfer().pendingCount()).isZero();
+        // stuck threshold still surfaces even when the source is unavailable.
+        assertThat(dto.transfer().stuckThresholdMinutes()).isEqualTo(60L);
+    }
+}

--- a/ecm-frontend/src/components/admin/QueueBacklogCard.test.tsx
+++ b/ecm-frontend/src/components/admin/QueueBacklogCard.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import QueueBacklogCard, { QueueBacklogSummary } from './QueueBacklogCard';
+import apiService from '../../services/api';
+
+jest.mock('../../services/api', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+jest.mock('react-toastify', () => ({ toast: { warn: jest.fn() } }));
+
+const mockedGet = apiService.get as jest.Mock;
+
+const summary: QueueBacklogSummary = {
+  ocr: { available: true, pendingDepth: 7, oldestPendingAgeSeconds: 120 },
+  mail: { available: true, lastSuccessAt: '2026-06-26T09:00:00', errorRate: 0.2, errors: 2, status: 'DEGRADED' },
+  transfer: {
+    available: true,
+    pendingCount: 3,
+    runningCount: 1,
+    failedCount: 2,
+    oldestPendingAgeSeconds: 1800,
+    stuckRunningCount: 1,
+    stuckThresholdMinutes: 60,
+  },
+};
+
+describe('QueueBacklogCard', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the three backlog panels with data', async () => {
+    mockedGet.mockResolvedValueOnce(summary);
+
+    render(<QueueBacklogCard />);
+
+    expect(await screen.findByText('OCR')).toBeTruthy();
+    expect(screen.getByText('Mail fetch')).toBeTruthy();
+    expect(screen.getByText('Transfer replication')).toBeTruthy();
+    // mail status chip
+    expect(screen.getByText('DEGRADED')).toBeTruthy();
+  });
+
+  it('renders a per-subsystem "unavailable" note without breaking the other panels', async () => {
+    mockedGet.mockResolvedValueOnce({
+      ...summary,
+      ocr: { available: false, pendingDepth: 0, oldestPendingAgeSeconds: null },
+    });
+
+    render(<QueueBacklogCard />);
+
+    expect(await screen.findByText('OCR')).toBeTruthy();
+    expect(screen.getByText('unavailable')).toBeTruthy();
+    // the other panels still render
+    expect(screen.getByText('Transfer replication')).toBeTruthy();
+  });
+
+  it('isolates a fetch failure: shows a warning and does not render the panels or crash', async () => {
+    mockedGet.mockRejectedValueOnce(new Error('boom'));
+
+    render(<QueueBacklogCard />);
+
+    expect(await screen.findByText(/unavailable right now/i)).toBeTruthy();
+    expect(screen.queryByText('Transfer replication')).toBeNull();
+  });
+});

--- a/ecm-frontend/src/components/admin/QueueBacklogCard.tsx
+++ b/ecm-frontend/src/components/admin/QueueBacklogCard.tsx
@@ -1,0 +1,166 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { toast } from 'react-toastify';
+import apiService from '../../services/api';
+
+export interface QueueBacklogSummary {
+  ocr: {
+    available: boolean;
+    pendingDepth: number;
+    oldestPendingAgeSeconds: number | null;
+  };
+  mail: {
+    available: boolean;
+    lastSuccessAt: string | null;
+    errorRate: number;
+    errors: number;
+    status: string | null;
+  };
+  transfer: {
+    available: boolean;
+    pendingCount: number;
+    runningCount: number;
+    failedCount: number;
+    oldestPendingAgeSeconds: number | null;
+    stuckRunningCount: number;
+    stuckThresholdMinutes: number;
+  };
+}
+
+const fmtAge = (seconds: number | null): string => {
+  if (seconds == null) {
+    return '—';
+  }
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+};
+
+const fmtTime = (iso: string | null): string => (iso ? new Date(iso).toLocaleString() : '—');
+
+const Unavailable: React.FC = () => (
+  <Typography variant="body2" color="text.disabled">
+    unavailable
+  </Typography>
+);
+
+/**
+ * Read-only "Queue Backlog" card (Day-2 queue backlog observability). Fetches OCR / mail / transfer
+ * backlog independently and is FAILURE-ISOLATED: a fetch error shows a local warning + toast and never
+ * breaks the surrounding AdminDashboard panels. A single unavailable subsystem renders a muted note for
+ * its panel only. Observability only — no requeue / cancel / trigger.
+ */
+const QueueBacklogCard: React.FC = () => {
+  const [data, setData] = useState<QueueBacklogSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      setLoading(true);
+      setFailed(false);
+      try {
+        const res = await apiService.get<QueueBacklogSummary>('/admin/queue-backlog');
+        if (active) {
+          setData(res ?? null);
+        }
+      } catch {
+        if (active) {
+          setFailed(true);
+          toast.warn('Failed to load queue backlog');
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Queue Backlog
+        </Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          Read-only OCR / mail / transfer backlog (depth, oldest-pending, failures). Observability only — no requeue or cancel.
+        </Typography>
+        {loading && (
+          <Box py={2} display="flex" justifyContent="center">
+            <CircularProgress size={24} />
+          </Box>
+        )}
+        {!loading && failed && (
+          <Alert severity="warning">Queue backlog is unavailable right now.</Alert>
+        )}
+        {!loading && !failed && data && (
+          <Stack divider={<Divider flexItem />} spacing={2}>
+            <Box>
+              <Typography variant="subtitle2">OCR</Typography>
+              {data.ocr.available ? (
+                <Typography variant="body2" color="text.secondary">
+                  Pending depth: <b>{data.ocr.pendingDepth}</b> · Oldest pending: <b>{fmtAge(data.ocr.oldestPendingAgeSeconds)}</b>
+                </Typography>
+              ) : (
+                <Unavailable />
+              )}
+            </Box>
+
+            <Box>
+              <Typography variant="subtitle2">Mail fetch</Typography>
+              {data.mail.available ? (
+                <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                  <Chip
+                    size="small"
+                    label={data.mail.status ?? 'UNKNOWN'}
+                    color={data.mail.errorRate > 0 ? 'warning' : 'success'}
+                  />
+                  <Typography variant="body2" color="text.secondary">
+                    Last success: <b>{fmtTime(data.mail.lastSuccessAt)}</b> · Error rate: <b>{Math.round(data.mail.errorRate * 100)}%</b> · Errors: <b>{data.mail.errors}</b>
+                  </Typography>
+                </Stack>
+              ) : (
+                <Unavailable />
+              )}
+            </Box>
+
+            <Box>
+              <Typography variant="subtitle2">Transfer replication</Typography>
+              {data.transfer.available ? (
+                <Typography variant="body2" color="text.secondary">
+                  Pending: <b>{data.transfer.pendingCount}</b> · Running: <b>{data.transfer.runningCount}</b> · Failed: <b>{data.transfer.failedCount}</b>
+                  {' · '}Oldest pending: <b>{fmtAge(data.transfer.oldestPendingAgeSeconds)}</b>
+                  {' · '}RUNNING &gt; {data.transfer.stuckThresholdMinutes}m: <b>{data.transfer.stuckRunningCount}</b>
+                </Typography>
+              ) : (
+                <Unavailable />
+              )}
+            </Box>
+          </Stack>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default QueueBacklogCard;

--- a/ecm-frontend/src/pages/AdminDashboard.tsx
+++ b/ecm-frontend/src/pages/AdminDashboard.tsx
@@ -71,6 +71,7 @@ import {
 import { format } from 'date-fns';
 import apiService from '../services/api';
 import ScheduledJobsCard from '../components/admin/ScheduledJobsCard';
+import QueueBacklogCard from '../components/admin/QueueBacklogCard';
 import { toast } from 'react-toastify';
 import userGroupService, { Group } from 'services/userGroupService';
 import savedSearchService, { SavedSearch } from 'services/savedSearchService';
@@ -2567,6 +2568,10 @@ const AdminDashboard: React.FC = () => {
 
         <Box mb={3}>
           <ScheduledJobsCard />
+        </Box>
+
+        <Box mb={3}>
+          <QueueBacklogCard />
         </Box>
 
         <Paper sx={{ p: 2, mb: 3 }}>


### PR DESCRIPTION
## Summary
Day-2 of the Queue Backlog observability line (taskbook **#43**; ratified §7 + the **§5A index-first guard**). A read-only "Queue Backlog" admin card for the three subsystems left after scheduler-run.

## Added
- **Transfer (full):** `ReplicationJobRepository.countByStatus` / `findFirstByStatusOrderByCreatedAtAsc` / `countByStatusAndStartedAtBefore`; pending/running/failed/oldest/stuck (configurable threshold, display-only).
- **OCR (depth+oldest):** `OcrQueueService.getBacklogSnapshot()` — Redis `scheduledCount()`/`peek()` O(1); failed/running **deferred** (an unindexed `Document.metadata` scan).
- **Mail (fetch-health):** account-level last-fetch window from `MailAccountRepository` (same `HEALTHY|DEGRADED|DOWN|UNKNOWN` semantics as runtime metrics for the fields this card needs); **no** `countByStatus` on unindexed `ProcessedMail.status`, and no `mail_processed_messages` aggregation for this card (§5A).
- `QueueBacklogObservabilityService` (each source wrapped → `available=false`, **never throws**) → `QueueBacklogAdminController` `GET /api/(v1/)admin/queue-backlog` (hasRole ADMIN) → AdminDashboard "Queue Backlog" card (failure-isolated).

## §5A index-first — held
Transfer uses existing indexed status/created-at signals; mail uses account-level last-fetch state only; OCR uses Redis O(1) reads. No migration needed.

## Boundaries
Read-only (no requeue/cancel/trigger); no retry/schedule change; stuck display-only (no risk levels / alerting); reuse AdminDashboard; preview / scheduler-run / governance domains untouched.

## Verification — local before push
Backend `./mvnw '-Dtest=QueueBacklog*' test` → **6 tests / 0 failures, BUILD SUCCESS**. Frontend `react-scripts test QueueBacklogCard` passed on the prior head; this push changes backend mail aggregation only.

Notes: transfer repo queries are exercised via a mocked-repo service test (`ReplicationJob` has a jsonb column that complicates `@DataJpaTest`); derived query names validate at Spring context bootstrap. OCR oldest-age = how *overdue* the earliest item is (the Redis ZSET score is scheduled-time, not enqueue-time) — documented.
