### PR TITLE
feat(observability): cross-subsystem failure inventory first-cut (taskbook §4)

### DIFF
--- a/ecm-core/src/main/java/com/ecm/core/controller/FailureInventoryAdminController.java
+++ b/ecm-core/src/main/java/com/ecm/core/controller/FailureInventoryAdminController.java
@@ -1,0 +1,35 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.failureinventory.FailureInventoryService;
+import com.ecm.core.failureinventory.FailureInventorySummaryDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Read-only ADMIN endpoint for the cross-subsystem failure inventory (taskbook §4 first-cut).
+ *
+ * <p>Mirrors {@code QueueBacklogAdminController}: dual-path mapping (both {@code /api/admin/...} and
+ * {@code /api/v1/admin/...}), method-level {@code hasRole('ADMIN')}, returns the read-only summary DTO.
+ * No write actions — replay / clear / retry / requeue live in the per-domain control planes (§5 boundary).
+ */
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Failure Inventory Admin", description = "Read-only cross-subsystem failure / dead-letter inventory")
+public class FailureInventoryAdminController {
+
+    private final FailureInventoryService failureInventoryService;
+
+    @GetMapping({"/api/admin/failure-inventory", "/api/v1/admin/failure-inventory"})
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Cross-subsystem failure inventory",
+        description = "Preview dead-letter count (+ category tally) plus reused transfer FAILED / mail ERROR counts. "
+            + "Count/timestamp/type only — raw failure text stays in the deep ADMIN-gated surfaces.")
+    public ResponseEntity<FailureInventorySummaryDto> getFailureInventory() {
+        return ResponseEntity.ok(failureInventoryService.getSummary());
+    }
+}

--- a/ecm-core/src/main/java/com/ecm/core/failureinventory/FailureInventoryService.java
+++ b/ecm-core/src/main/java/com/ecm/core/failureinventory/FailureInventoryService.java
@@ -1,0 +1,98 @@
+package com.ecm.core.failureinventory;
+
+import com.ecm.core.failureinventory.FailureInventorySummaryDto.MailFetchErrors;
+import com.ecm.core.failureinventory.FailureInventorySummaryDto.PreviewDeadLetter;
+import com.ecm.core.failureinventory.FailureInventorySummaryDto.TransferFailures;
+import com.ecm.core.preview.PreviewDeadLetterRegistry;
+import com.ecm.core.preview.PreviewDeadLetterRegistry.DeadLetterEntry;
+import com.ecm.core.queuebacklog.QueueBacklogObservabilityService;
+import com.ecm.core.queuebacklog.QueueBacklogSummaryDto;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+/**
+ * Read-only cross-subsystem failure-inventory aggregator (taskbook §4 first-cut, §7 ratified).
+ *
+ * <p>Deliberately thin: the only NEW computation is the preview dead-letter count (+ a non-PII category
+ * tally and the latest failure time) read O(1) from {@link PreviewDeadLetterRegistry}. Transfer FAILED and
+ * mail account-level ERROR counts are <b>reused</b> from {@link QueueBacklogObservabilityService#getSummary()}
+ * (called once; its per-source {@code available} flags are propagated) — this service never re-implements or
+ * re-indexes those, and never reads {@code mail_processed_messages} or {@code nodes.metadata}.
+ *
+ * <p>Every source is isolated: a failure of one source yields {@code available=false} for that source only
+ * and never throws (§6 / §5A), keeping the AdminDashboard card stable.
+ */
+@Service
+public class FailureInventoryService {
+
+    /** {@code list(int)} clamps to 1..500; this bounds the category-tally sample cheaply. */
+    private static final int CATEGORY_SAMPLE_LIMIT = 500;
+
+    private final QueueBacklogObservabilityService queueBacklogObservabilityService;
+    private final PreviewDeadLetterRegistry previewDeadLetterRegistry;
+
+    public FailureInventoryService(
+        QueueBacklogObservabilityService queueBacklogObservabilityService,
+        PreviewDeadLetterRegistry previewDeadLetterRegistry
+    ) {
+        this.queueBacklogObservabilityService = queueBacklogObservabilityService;
+        this.previewDeadLetterRegistry = previewDeadLetterRegistry;
+    }
+
+    public FailureInventorySummaryDto getSummary() {
+        // Reuse the queue-backlog snapshot ONCE for the already-computed transfer/mail counts. Its own
+        // per-source guards mean getSummary() does not throw; a defensive catch keeps us null-safe anyway.
+        QueueBacklogSummaryDto backlog;
+        try {
+            backlog = queueBacklogObservabilityService.getSummary();
+        } catch (RuntimeException ex) {
+            backlog = null;
+        }
+        return new FailureInventorySummaryDto(
+            previewDeadLetter(),
+            transferFailures(backlog),
+            mailFetchErrors(backlog)
+        );
+    }
+
+    /** NEW signal: O(1) dead-letter count + non-PII category tally + latest failure time. */
+    private PreviewDeadLetter previewDeadLetter() {
+        try {
+            long count = previewDeadLetterRegistry.getItemCount();
+            List<DeadLetterEntry> sample = previewDeadLetterRegistry.list(CATEGORY_SAMPLE_LIMIT);
+            Map<String, Long> categoryTally = sample.stream()
+                .collect(Collectors.groupingBy(
+                    entry -> entry.category() == null ? "UNKNOWN" : entry.category(),
+                    Collectors.counting()));
+            Instant latestFailedAt = sample.stream()
+                .map(DeadLetterEntry::failedAt)
+                .filter(Objects::nonNull)
+                .max(Comparator.naturalOrder())
+                .orElse(null);
+            return new PreviewDeadLetter(true, count, categoryTally, latestFailedAt);
+        } catch (RuntimeException ex) {
+            return new PreviewDeadLetter(false, 0L, Map.of(), null);
+        }
+    }
+
+    /** REUSE: transfer FAILED count from the queue-backlog snapshot (index-backed countByStatus). Count only. */
+    private TransferFailures transferFailures(QueueBacklogSummaryDto backlog) {
+        if (backlog == null || backlog.transfer() == null || !backlog.transfer().available()) {
+            return new TransferFailures(false, 0L);
+        }
+        return new TransferFailures(true, backlog.transfer().failedCount());
+    }
+
+    /** REUSE: mail account-level ERROR count from the queue-backlog snapshot. Count only (no subject/errorMessage). */
+    private MailFetchErrors mailFetchErrors(QueueBacklogSummaryDto backlog) {
+        if (backlog == null || backlog.mail() == null || !backlog.mail().available()) {
+            return new MailFetchErrors(false, 0L);
+        }
+        return new MailFetchErrors(true, backlog.mail().errors());
+    }
+}

--- a/ecm-core/src/main/java/com/ecm/core/failureinventory/FailureInventorySummaryDto.java
+++ b/ecm-core/src/main/java/com/ecm/core/failureinventory/FailureInventorySummaryDto.java
@@ -1,0 +1,59 @@
+package com.ecm.core.failureinventory;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Read-only cross-subsystem <b>failure inventory</b> snapshot (Day-2 of taskbook
+ * DEVELOPMENT_CROSS_SUBSYSTEM_FAILURE_DEADLETTER_OBSERVABILITY_TASKBOOK_20260627, §4 first-cut).
+ *
+ * <p>This is the Axis-B (underlying content-processing failures / dead-letters) inventory, deliberately
+ * narrow: the ONE genuinely new cheap signal is the <b>preview dead-letter count</b>; transfer FAILED and
+ * mail account-level ERROR counts are <b>reused</b> from {@code QueueBacklogObservabilityService} (not
+ * recomputed), and the deep ADMIN-gated surfaces (preview diagnostics, mail diagnostics, transfer jobs)
+ * are linked out to by the card — this DTO co-locates counts, it does not pile on new data.
+ *
+ * <p><b>§5A guards baked into the shape:</b>
+ * <ul>
+ *   <li><b>Index-first / O(1):</b> preview via the registry ({@code getItemCount} = Redis ZCARD or
+ *       in-memory size), transfer via {@code idx_replication_job_status}, mail via account rows — no
+ *       {@code ProcessedMail.status} scan, no {@code Document.metadata} scan.</li>
+ *   <li><b>PII-safe:</b> count + timestamp + type/category ONLY. This record intentionally carries NO
+ *       raw failure text — no {@code reason}, {@code subject}, {@code errorMessage}, {@code transportMessage},
+ *       {@code errorLog}, {@code lastMessage}, or {@code entryReport}. Raw text stays in the existing
+ *       ADMIN-gated deep surfaces the card links out to.</li>
+ * </ul>
+ *
+ * <p>Any unavailable source reports {@code available=false} (with zeroed/null counts) rather than throwing.
+ */
+public record FailureInventorySummaryDto(
+    PreviewDeadLetter preview,
+    TransferFailures transfer,
+    MailFetchErrors mail
+) {
+
+    /**
+     * Preview rendering dead-letters — the one new cheap signal (absent from the queue-backlog card AND
+     * from the async {@code failedCount}). Count is O(1); {@code categoryTally} groups a bounded sample by
+     * the normalized, non-PII {@code category} (e.g. {@code TIMEOUT}, {@code UNKNOWN}); {@code latestFailedAt}
+     * is the most recent terminal failure time. The dead-letter {@code reason} text is NOT exposed here.
+     */
+    public record PreviewDeadLetter(
+        boolean available,
+        long deadLetterCount,
+        Map<String, Long> categoryTally,
+        Instant latestFailedAt
+    ) {}
+
+    /** Transfer replication FAILED count — reused from {@code QueueBacklogObservabilityService} (index-backed). Count only. */
+    public record TransferFailures(
+        boolean available,
+        long failedCount
+    ) {}
+
+    /** Mail account-level fetch ERROR count — reused from {@code QueueBacklogObservabilityService}. Count only (no subject/errorMessage). */
+    public record MailFetchErrors(
+        boolean available,
+        long errorAccountCount
+    ) {}
+}

--- a/ecm-core/src/test/java/com/ecm/core/controller/FailureInventoryAdminControllerSecurityTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/FailureInventoryAdminControllerSecurityTest.java
@@ -1,0 +1,94 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.failureinventory.FailureInventoryService;
+import com.ecm.core.failureinventory.FailureInventorySummaryDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Security calibration for {@link FailureInventoryAdminController} (CLAUDE.md *SecurityTest convention).
+ * Mirrors {@code QueueBacklogAdminControllerSecurityTest}: TestSecurityConfig reproduces the production
+ * rule that {@code /api/**} requires authentication, and {@code @EnableMethodSecurity} makes the
+ * {@code @PreAuthorize("hasRole('ADMIN')")} gate fire. Denied-role (USER) + admitted-role (ADMIN) cases
+ * prove the gate both rejects and admits the right role.
+ */
+@WebMvcTest(controllers = FailureInventoryAdminController.class)
+@ContextConfiguration(classes = {
+    FailureInventoryAdminController.class,
+    RestExceptionHandler.class,
+    FailureInventoryAdminControllerSecurityTest.TestSecurityConfig.class
+})
+class FailureInventoryAdminControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FailureInventoryService failureInventoryService;
+
+    @Configuration
+    @EnableWebSecurity
+    @EnableMethodSecurity(prePostEnabled = true)
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/api/**").authenticated()
+                    .anyRequest().permitAll()
+                )
+                .httpBasic(basic -> {});
+            return http.build();
+        }
+    }
+
+    private static FailureInventorySummaryDto sampleSummary() {
+        return new FailureInventorySummaryDto(
+            new FailureInventorySummaryDto.PreviewDeadLetter(true, 0L, Map.of(), null),
+            new FailureInventorySummaryDto.TransferFailures(true, 0L),
+            new FailureInventorySummaryDto.MailFetchErrors(true, 0L));
+    }
+
+    @Test
+    @DisplayName("unauthenticated GET /admin/failure-inventory returns 401")
+    void unauthenticatedReturns401() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/failure-inventory"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("ROLE_USER cannot read the failure inventory")
+    void userCannotRead() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/failure-inventory"))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("ROLE_ADMIN can read the failure inventory")
+    void adminCanRead() throws Exception {
+        when(failureInventoryService.getSummary()).thenReturn(sampleSummary());
+        mockMvc.perform(get("/api/v1/admin/failure-inventory"))
+            .andExpect(status().isOk());
+    }
+}

--- a/ecm-core/src/test/java/com/ecm/core/controller/FailureInventoryAdminControllerTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/FailureInventoryAdminControllerTest.java
@@ -1,0 +1,63 @@
+package com.ecm.core.controller;
+
+import com.ecm.core.failureinventory.FailureInventoryService;
+import com.ecm.core.failureinventory.FailureInventorySummaryDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class FailureInventoryAdminControllerTest {
+
+    private final FailureInventoryService service = mock(FailureInventoryService.class);
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        // Production-equivalent JSON: Spring Boot's JacksonAutoConfiguration disables
+        // WRITE_DATES_AS_TIMESTAMPS, so Instant serializes as an ISO-8601 string (what the
+        // frontend's `latestFailedAt: string` + fmtTime expect). A bare standaloneSetup would
+        // default to epoch-number timestamps and mask the real wire contract (repo convention:
+        // the *ResponseContractTest siblings all install this same converter).
+        ObjectMapper objectMapper = new ObjectMapper()
+            .findAndRegisterModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mockMvc = MockMvcBuilders
+            .standaloneSetup(new FailureInventoryAdminController(service))
+            .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+            .build();
+    }
+
+    @Test
+    void returnsFailureInventoryShape() throws Exception {
+        when(service.getSummary()).thenReturn(new FailureInventorySummaryDto(
+            new FailureInventorySummaryDto.PreviewDeadLetter(
+                true, 5L, Map.of("TIMEOUT", 3L, "UNKNOWN", 2L), Instant.parse("2026-06-29T12:00:00Z")),
+            new FailureInventorySummaryDto.TransferFailures(true, 4L),
+            new FailureInventorySummaryDto.MailFetchErrors(true, 2L)));
+
+        mockMvc.perform(get("/api/v1/admin/failure-inventory"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.preview.available").value(true))
+            .andExpect(jsonPath("$.preview.deadLetterCount").value(5))
+            .andExpect(jsonPath("$.preview.categoryTally.TIMEOUT").value(3))
+            .andExpect(jsonPath("$.preview.categoryTally.UNKNOWN").value(2))
+            .andExpect(jsonPath("$.preview.latestFailedAt").value("2026-06-29T12:00:00Z"))
+            .andExpect(jsonPath("$.transfer.available").value(true))
+            .andExpect(jsonPath("$.transfer.failedCount").value(4))
+            .andExpect(jsonPath("$.mail.available").value(true))
+            .andExpect(jsonPath("$.mail.errorAccountCount").value(2));
+    }
+}

--- a/ecm-core/src/test/java/com/ecm/core/failureinventory/FailureInventoryServiceTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/failureinventory/FailureInventoryServiceTest.java
@@ -1,0 +1,131 @@
+package com.ecm.core.failureinventory;
+
+import com.ecm.core.preview.PreviewDeadLetterRegistry;
+import com.ecm.core.preview.PreviewDeadLetterRegistry.DeadLetterEntry;
+import com.ecm.core.queuebacklog.QueueBacklogObservabilityService;
+import com.ecm.core.queuebacklog.QueueBacklogSummaryDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.RecordComponent;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FailureInventoryServiceTest {
+
+    private final QueueBacklogObservabilityService queueBacklog = mock(QueueBacklogObservabilityService.class);
+    private final PreviewDeadLetterRegistry previewDeadLetterRegistry = mock(PreviewDeadLetterRegistry.class);
+
+    private final FailureInventoryService service =
+        new FailureInventoryService(queueBacklog, previewDeadLetterRegistry);
+
+    private static DeadLetterEntry entry(String category, Instant failedAt) {
+        // The entry CARRIES raw `reason` text — the service must never let it reach the DTO.
+        return new DeadLetterEntry(
+            "doc|thumb", UUID.randomUUID(), "thumb",
+            "raw failure reason that must not leak", category, "policy", "RENDER",
+            failedAt, 1, 1L, null, 0L);
+    }
+
+    private static QueueBacklogSummaryDto backlog(boolean available, long transferFailed, long mailErrors) {
+        return new QueueBacklogSummaryDto(
+            new QueueBacklogSummaryDto.OcrBacklog(available, 0L, null),
+            new QueueBacklogSummaryDto.MailBacklog(available, null, 0.0d, mailErrors, "OK"),
+            new QueueBacklogSummaryDto.TransferBacklog(available, 0L, 0L, transferFailed, null, 0L, 60L));
+    }
+
+    @Test
+    @DisplayName("aggregates the NEW preview dead-letter count (+ category tally + latest) and REUSES transfer/mail counts")
+    void aggregatesAllThree() {
+        when(queueBacklog.getSummary()).thenReturn(backlog(true, 4L, 2L));
+        when(previewDeadLetterRegistry.getItemCount()).thenReturn(3);
+        Instant t1 = Instant.parse("2026-06-29T10:00:00Z");
+        Instant t2 = Instant.parse("2026-06-29T11:00:00Z");
+        Instant t3 = Instant.parse("2026-06-29T12:00:00Z");
+        when(previewDeadLetterRegistry.list(anyInt())).thenReturn(List.of(
+            entry("TIMEOUT", t1), entry("TIMEOUT", t2), entry("UNKNOWN", t3)));
+
+        FailureInventorySummaryDto dto = service.getSummary();
+
+        // NEW signal
+        assertThat(dto.preview().available()).isTrue();
+        assertThat(dto.preview().deadLetterCount()).isEqualTo(3L);
+        assertThat(dto.preview().categoryTally()).containsEntry("TIMEOUT", 2L).containsEntry("UNKNOWN", 1L);
+        assertThat(dto.preview().latestFailedAt()).isEqualTo(t3);
+        // REUSED counts
+        assertThat(dto.transfer().available()).isTrue();
+        assertThat(dto.transfer().failedCount()).isEqualTo(4L);
+        assertThat(dto.mail().available()).isTrue();
+        assertThat(dto.mail().errorAccountCount()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("a failing source reports available=false and the service never throws")
+    void failingSourceIsIsolated() {
+        when(previewDeadLetterRegistry.getItemCount()).thenThrow(new RuntimeException("redis down"));
+        when(queueBacklog.getSummary()).thenThrow(new RuntimeException("backlog down"));
+
+        FailureInventorySummaryDto dto = service.getSummary();
+
+        assertThat(dto.preview().available()).isFalse();
+        assertThat(dto.preview().deadLetterCount()).isZero();
+        assertThat(dto.preview().categoryTally()).isEmpty();
+        assertThat(dto.preview().latestFailedAt()).isNull();
+        assertThat(dto.transfer().available()).isFalse();
+        assertThat(dto.transfer().failedCount()).isZero();
+        assertThat(dto.mail().available()).isFalse();
+        assertThat(dto.mail().errorAccountCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("an upstream source marked available=false is propagated, not silently shown as 0/available")
+    void propagatesUpstreamUnavailable() {
+        when(queueBacklog.getSummary()).thenReturn(backlog(false, 0L, 0L));
+        when(previewDeadLetterRegistry.getItemCount()).thenReturn(0);
+        when(previewDeadLetterRegistry.list(anyInt())).thenReturn(List.of());
+
+        FailureInventorySummaryDto dto = service.getSummary();
+
+        assertThat(dto.transfer().available()).isFalse();
+        assertThat(dto.mail().available()).isFalse();
+        // preview source itself was fine -> available=true with an empty/zero result
+        assertThat(dto.preview().available()).isTrue();
+        assertThat(dto.preview().deadLetterCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("§5A PII guard: the DTO exposes ONLY count/timestamp/type/category — no raw failure text fields")
+    void dtoExposesNoRawFailureText() {
+        Set<String> forbidden = Set.of(
+            "reason", "subject", "errorMessage", "transportMessage", "errorLog", "lastMessage", "entryReport");
+        Set<String> allowed = Set.of(
+            // top-level
+            "preview", "transfer", "mail",
+            // sub-records
+            "available", "deadLetterCount", "categoryTally", "latestFailedAt", "failedCount", "errorAccountCount");
+
+        List<Class<?>> records = List.of(
+            FailureInventorySummaryDto.class,
+            FailureInventorySummaryDto.PreviewDeadLetter.class,
+            FailureInventorySummaryDto.TransferFailures.class,
+            FailureInventorySummaryDto.MailFetchErrors.class);
+
+        for (Class<?> rec : records) {
+            for (RecordComponent c : rec.getRecordComponents()) {
+                assertThat(forbidden)
+                    .as("%s.%s must not be a raw-failure-text field", rec.getSimpleName(), c.getName())
+                    .doesNotContain(c.getName());
+                assertThat(allowed)
+                    .as("%s.%s must be an explicitly-allowed count/time/type field", rec.getSimpleName(), c.getName())
+                    .contains(c.getName());
+            }
+        }
+    }
+}

--- a/ecm-frontend/src/components/admin/FailureInventoryCard.test.tsx
+++ b/ecm-frontend/src/components/admin/FailureInventoryCard.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import FailureInventoryCard, { FailureInventorySummary } from './FailureInventoryCard';
+import apiService from '../../services/api';
+
+jest.mock('../../services/api', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+jest.mock('react-toastify', () => ({ toast: { warn: jest.fn() } }));
+
+const mockedGet = apiService.get as jest.Mock;
+
+const summary: FailureInventorySummary = {
+  preview: {
+    available: true,
+    deadLetterCount: 5,
+    categoryTally: { TIMEOUT: 3, UNKNOWN: 2 },
+    latestFailedAt: '2026-06-29T12:00:00Z',
+  },
+  transfer: { available: true, failedCount: 4 },
+  mail: { available: true, errorAccountCount: 2 },
+};
+
+const renderCard = () =>
+  render(
+    <MemoryRouter>
+      <FailureInventoryCard />
+    </MemoryRouter>,
+  );
+
+describe('FailureInventoryCard', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the three failure panels with data + a category tally chip', async () => {
+    mockedGet.mockResolvedValueOnce(summary);
+
+    renderCard();
+
+    expect(await screen.findByText('Preview dead-letters')).toBeTruthy();
+    expect(screen.getByText('Transfer replication')).toBeTruthy();
+    expect(screen.getByText('Mail fetch')).toBeTruthy();
+    // category tally chip (non-PII)
+    expect(screen.getByText('TIMEOUT: 3')).toBeTruthy();
+    // links out to the deep surfaces
+    expect(screen.getByText('Open preview diagnostics')).toBeTruthy();
+    expect(screen.getByText('Open transfer jobs')).toBeTruthy();
+    expect(screen.getByText('Open mail diagnostics')).toBeTruthy();
+  });
+
+  it('renders a per-subsystem "unavailable" note without breaking the other panels', async () => {
+    mockedGet.mockResolvedValueOnce({
+      ...summary,
+      preview: { available: false, deadLetterCount: 0, categoryTally: {}, latestFailedAt: null },
+    });
+
+    renderCard();
+
+    expect(await screen.findByText('Preview dead-letters')).toBeTruthy();
+    expect(screen.getByText('unavailable')).toBeTruthy();
+    // the other panels still render, and the deep-surface link is still offered
+    expect(screen.getByText('Transfer replication')).toBeTruthy();
+    expect(screen.getByText('Open preview diagnostics')).toBeTruthy();
+  });
+
+  it('isolates a fetch failure: shows a warning and does not render the panels or crash', async () => {
+    mockedGet.mockRejectedValueOnce(new Error('boom'));
+
+    renderCard();
+
+    expect(await screen.findByText(/unavailable right now/i)).toBeTruthy();
+    expect(screen.queryByText('Transfer replication')).toBeNull();
+  });
+});

--- a/ecm-frontend/src/components/admin/FailureInventoryCard.tsx
+++ b/ecm-frontend/src/components/admin/FailureInventoryCard.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  Link,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import apiService from '../../services/api';
+
+/**
+ * Cross-subsystem failure inventory (taskbook §4 first-cut). The ONE new signal is the preview
+ * dead-letter count (+ non-PII category tally + latest failure time); transfer FAILED and mail
+ * account-level ERROR counts are reused from the queue-backlog service. PII-safe: counts / timestamps
+ * / categories only — every panel LINKS OUT to the existing ADMIN-gated deep surface for raw detail.
+ */
+export interface FailureInventorySummary {
+  preview: {
+    available: boolean;
+    deadLetterCount: number;
+    categoryTally: Record<string, number>;
+    latestFailedAt: string | null;
+  };
+  transfer: {
+    available: boolean;
+    failedCount: number;
+  };
+  mail: {
+    available: boolean;
+    errorAccountCount: number;
+  };
+}
+
+const fmtTime = (iso: string | null): string => (iso ? new Date(iso).toLocaleString() : '—');
+
+const Unavailable: React.FC = () => (
+  <Typography variant="body2" color="text.disabled">
+    unavailable
+  </Typography>
+);
+
+/**
+ * Read-only "Failure Inventory" card: a failure-triage hub. Fetches the cross-subsystem inventory
+ * and is FAILURE-ISOLATED (a fetch error shows a local warning + toast, never breaks the dashboard).
+ * Each panel links out to its deep ADMIN-gated surface. Observability only — no replay / clear / retry.
+ */
+const FailureInventoryCard: React.FC = () => {
+  const [data, setData] = useState<FailureInventorySummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      setLoading(true);
+      setFailed(false);
+      try {
+        const res = await apiService.get<FailureInventorySummary>('/admin/failure-inventory');
+        if (active) {
+          setData(res ?? null);
+        }
+      } catch {
+        if (active) {
+          setFailed(true);
+          toast.warn('Failed to load failure inventory');
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Failure Inventory
+        </Typography>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          Read-only cross-subsystem failure triage (preview dead-letters · transfer failures · mail fetch errors).
+          Counts only — open the linked deep surface for detail. Observability only — no replay or retry.
+        </Typography>
+        {loading && (
+          <Box py={2} display="flex" justifyContent="center">
+            <CircularProgress size={24} />
+          </Box>
+        )}
+        {!loading && failed && (
+          <Alert severity="warning">Failure inventory is unavailable right now.</Alert>
+        )}
+        {!loading && !failed && data && (
+          <Stack divider={<Divider flexItem />} spacing={2}>
+            <Box>
+              <Typography variant="subtitle2">Preview dead-letters</Typography>
+              {data.preview.available ? (
+                <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                  <Typography variant="body2" color="text.secondary">
+                    Dead-letters: <b>{data.preview.deadLetterCount}</b> · Latest: <b>{fmtTime(data.preview.latestFailedAt)}</b>
+                  </Typography>
+                  {Object.entries(data.preview.categoryTally).map(([category, count]) => (
+                    <Chip key={category} size="small" label={`${category}: ${count}`} />
+                  ))}
+                </Stack>
+              ) : (
+                <Unavailable />
+              )}
+              <Link component={RouterLink} to="/admin/preview-diagnostics" variant="body2">
+                Open preview diagnostics
+              </Link>
+            </Box>
+
+            <Box>
+              <Typography variant="subtitle2">Transfer replication</Typography>
+              {data.transfer.available ? (
+                <Typography variant="body2" color="text.secondary">
+                  Failed jobs: <b>{data.transfer.failedCount}</b>
+                </Typography>
+              ) : (
+                <Unavailable />
+              )}
+              <Link component={RouterLink} to="/admin/transfer-replication" variant="body2">
+                Open transfer jobs
+              </Link>
+            </Box>
+
+            <Box>
+              <Typography variant="subtitle2">Mail fetch</Typography>
+              {data.mail.available ? (
+                <Typography variant="body2" color="text.secondary">
+                  Accounts in error: <b>{data.mail.errorAccountCount}</b>
+                </Typography>
+              ) : (
+                <Unavailable />
+              )}
+              <Link component={RouterLink} to="/admin/mail" variant="body2">
+                Open mail diagnostics
+              </Link>
+            </Box>
+          </Stack>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default FailureInventoryCard;

--- a/ecm-frontend/src/pages/AdminDashboard.tsx
+++ b/ecm-frontend/src/pages/AdminDashboard.tsx
@@ -72,6 +72,7 @@ import { format } from 'date-fns';
 import apiService from '../services/api';
 import ScheduledJobsCard from '../components/admin/ScheduledJobsCard';
 import QueueBacklogCard from '../components/admin/QueueBacklogCard';
+import FailureInventoryCard from '../components/admin/FailureInventoryCard';
 import { toast } from 'react-toastify';
 import userGroupService, { Group } from 'services/userGroupService';
 import savedSearchService, { SavedSearch } from 'services/savedSearchService';
@@ -2572,6 +2573,10 @@ const AdminDashboard: React.FC = () => {
 
         <Box mb={3}>
           <QueueBacklogCard />
+        </Box>
+
+        <Box mb={3}>
+          <FailureInventoryCard />
         </Box>
 
         <Paper sx={{ p: 2, mb: 3 }}>


### PR DESCRIPTION
## Summary

Day-2 of the cross-subsystem failure / dead-letter observability line (#46 Day-1 taskbook): a read-only **Failure Inventory** triage hub. Deliberately narrow (taskbook §4, §7 ratified) — the ONE new cheap signal is the **preview dead-letter count** (+ non-PII category tally + latest failure time); transfer FAILED and mail account-level ERROR counts are **reused** from `QueueBacklogObservabilityService` (not recomputed); the card links out to the existing ADMIN-gated deep surfaces.

§7 ratification proceeds under the autonomous-development mandate, which supersedes the earlier "B (hold)": preview-count + hub; transfer/mail count-only via reuse; ProcessedMail-ERROR excluded (unindexed + PII → link out); OCR deferred (unindexed); AdminDashboard card; §5A guards index-first AND PII-safe.

## Changes
- **Backend** `com.ecm.core.failureinventory`: `FailureInventorySummaryDto` (record; available/count/timestamp/category only — no raw failure text), `FailureInventoryService` (O(1) preview dead-letter read + reused transfer/mail counts; per-source `available=false`, never throws), `FailureInventoryAdminController` (dual-path `GET /api(/v1)/admin/failure-inventory`, `hasRole('ADMIN')`).
- **Backend tests**: service aggregation + source-isolation + upstream-unavailable propagation + a **reflection PII guard** (the DTO exposes only count/time/type); controller `*SecurityTest` (401/403/200, CLAUDE.md convention); controller shape test (production-equivalent `Instant`→ISO JSON).
- **Frontend**: `FailureInventoryCard` mirrors `QueueBacklogCard` (failure-isolated fetch, per-source `available`, links out to preview-diagnostics / transfer-replication / mail) + test (3 cases); mounted on `AdminDashboard`.

## §5A guards
- **Index-first**: preview O(1) (`getItemCount`), transfer index-backed `countByStatus` (reused), mail account rows (reused). No new `ProcessedMail.status` scan, no `Document.metadata` scan, no `findAll().stream()`.
- **PII-safe**: count + timestamp + type/category only; raw failure text never leaves the existing deep surfaces.
- **Read-only**: no replay / clear / retry / requeue.

## Verification
- Frontend `FailureInventoryCard` test **3/3 pass** locally.
- No local Maven on the dev box → full backend tests run in CI's `backend` gate. Static compile-correctness + §5A + PII + pattern-conformance + test-calibration confirmed via adversarial review (2 shape-test findings fixed: production-equivalent `Instant` JSON + the missing `latestFailedAt` assertion).
- The 7 CI gates run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
