### PR TITLE
docs(observability): mark plan-completion snapshot superseded by #49

### DIFF
--- a/docs/DEVELOPMENT_PLAN_COMPLETION_AND_VERIFICATION_20260627.md
+++ b/docs/DEVELOPMENT_PLAN_COMPLETION_AND_VERIFICATION_20260627.md
@@ -1,5 +1,11 @@
 # Development Plan — Completion & Verification Status (2026-06-27)
 
+> **Superseded (2026-06-29):** the one remaining buildable item — the **cross-subsystem failure first-cut** — is
+> no longer held. It was ratified (§7), built, CI-verified **7/7 green**, and merged as **#48 (`df7ec2c`)**, with the
+> authoritative closeout in **`DEV_AND_VERIFICATION_CROSS_SUBSYSTEM_FAILURE_INVENTORY_20260629.md` (#49)**. The body
+> below remains an accurate **2026-06-27 point-in-time snapshot** (it predates the operator's autonomous-development
+> mandate that lifted the "hold"); only the §8 decision-gated items (#2–#5) now remain.
+
 - Date: 2026-06-27
 - Scope: the Athena ECM observability / governance development cadence — completion status, unfinished-item
   inventory, and verification.


### PR DESCRIPTION
## Summary

The 2026-06-27 `DEVELOPMENT_PLAN_COMPLETION_AND_VERIFICATION_20260627.md` snapshot still recorded the cross-subsystem failure first-cut as **held**. That hold was lifted under the autonomous-development mandate; the slice is built, **CI 7/7 green**, and merged (**#48 `df7ec2c`**), with the authoritative closeout in **#49** (`DEV_AND_VERIFICATION_CROSS_SUBSYSTEM_FAILURE_INVENTORY_20260629.md`).

Adds a top **"Superseded (2026-06-29)"** banner pointing to #49; the body stays an accurate point-in-time snapshot. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
