### PR TITLE
feat(failure-inventory): OCR FAILED/PROCESSING index slice (#3 Option A)

### DIFF
--- a/docs/DEV_AND_VERIFICATION_FAILURE_INVENTORY_OCR_INDEX_20260629.md
+++ b/docs/DEV_AND_VERIFICATION_FAILURE_INVENTORY_OCR_INDEX_20260629.md
@@ -1,0 +1,109 @@
+# Failure Inventory #3 — OCR Status Index (Option A) — Development & Verification (2026-06-29)
+
+## 1. State at a glance
+
+This slice closes taskbook item **#3** from
+`DEVELOPMENT_FAILURE_INVENTORY_OCR_MAIL_INDEX_PRIVACY_DECISION_TASKBOOK_20260629.md`
+by implementing the **Option A**口径 that taskbook recommended: promote the OCR state — today an
+**unindexed** `nodes.metadata["ocrStatus"]` jsonb key (`READY|PROCESSING|FAILED|SKIPPED`) — to a
+dedicated, indexed `documents.ocr_status` column, and surface FAILED / PROCESSING counts in the
+existing cross-subsystem Failure Inventory card built in §4.
+
+Decision recorded: **#3 = Option A** (indexed mirror column). Options B (live jsonb scan), C (reuse
+the queue-backlog OCR pending depth only), and D (defer) were not taken — A is the only option that
+gives an O(1) FAILED count without an O(n) jsonb scan and without conflating "failed" with "pending".
+
+## 2. What was built (code-grounded)
+
+The new failure signal is **two O(1) index counts**, nothing more.
+
+- **Schema** — `db/changelog/changes/095-add-document-ocr-status.xml` (+ master include after 094,
+  before 007-insert-initial-data): `addColumn documents.ocr_status varchar(32)` nullable +
+  `createIndex idx_document_ocr_status` + a **Postgres-only** one-time backfill
+  `UPDATE documents d SET ocr_status = n.metadata->>'ocrStatus' FROM nodes n WHERE n.id = d.id AND
+  n.metadata IS NOT NULL` (metadata lives on the JOINED parent `nodes` table; `documents.id =
+  nodes.id`). Rollback drops the index then the column.
+- **Entity** — `Document`: `@Index(name = "idx_document_ocr_status", columnList = "ocr_status")` on
+  `@Table` + `@Column(name = "ocr_status", length = 32) String ocrStatus` (length matches the DDL;
+  the module runs `ddl-auto: validate`).
+- **Write path** — `OcrQueueService` already owns every OCR transition; it now mirrors the status
+  onto the column at the two points it writes `metadata["ocrStatus"]` (`READY` on success;
+  `PROCESSING` / `FAILED` / `SKIPPED` via `setOcrMetadata`). The column is therefore kept current
+  going forward on every DBMS, independent of the Postgres-only backfill.
+- **Read path** — `DocumentRepository.countByOcrStatus(status)` =
+  `SELECT COUNT(d) … WHERE d.ocrStatus = :status AND d.deleted = false` (index-backed, count only).
+- **Aggregator** — `FailureInventoryService.ocrFailures()` returns
+  `OcrFailures(available, failedCount, runningCount)` from `countByOcrStatus("FAILED")` /
+  `("PROCESSING")`, wrapped in try/catch → `OcrFailures(false, 0, 0)` so an OCR/DB fault isolates to
+  this one source and never throws (same §6 isolation contract as the other three sources).
+- **DTO** — `FailureInventorySummaryDto` gains a 4th component `OcrFailures ocr`
+  (`boolean available, long failedCount, long runningCount`) — count only, **no** document name,
+  text, or failure reason.
+- **UI** — `FailureInventoryCard` gains an "OCR processing" panel showing `Failed` / `Processing`
+  counts (or `unavailable`). It intentionally carries **no "Open …" deep-surface link**: unlike the
+  preview/transfer/mail panels, OCR has no dedicated admin diagnostics route, so a caption
+  ("Per-document OCR state is shown on each document.") replaces a link that would point at nothing.
+
+## 3. PII / §5A guards — honored
+
+Count + boolean only. The `OcrFailures` record carries no `reason`, `subject`, `errorMessage`,
+document name, or text. The same reflection-guard test that protects the §4 DTO now also walks
+`OcrFailures` and asserts every component name is in the explicit allow-set
+(`available`, `failedCount`, `runningCount`). The read is index-first
+(`idx_document_ocr_status`), not a `nodes.metadata` jsonb scan.
+
+## 4. Verification
+
+### 4.1 Tests added / updated
+
+Backend (`ecm-core`):
+- `FailureInventoryServiceTest` — 3-arg ctor (mock `DocumentRepository`); the aggregation test now
+  stubs + asserts `ocr` FAILED/PROCESSING; the isolation test asserts `ocr.available=false` on a DB
+  fault; two new focused tests: `ocrCountsAreIndexFirst` (verifies `countByOcrStatus("FAILED")` +
+  `("PROCESSING")` are the only repository interactions) and `ocrSourceFailsClosedIndependently`
+  (OCR DB fault isolates; transfer/mail/preview stay healthy). Reflection-guard allow-set/records
+  list extended with `ocr`/`runningCount`/`OcrFailures.class`.
+- `FailureInventoryAdminControllerTest` — DTO built with the 4th arg; new `$.ocr.*` jsonPath
+  assertions.
+- `FailureInventoryAdminControllerSecurityTest` — `sampleSummary()` built with the 4th arg.
+
+Frontend (`ecm-frontend`):
+- `FailureInventoryCard.test.tsx` — `summary` mock gains `ocr`; the panel-count test now expects
+  four panels + the OCR caption; new tests assert OCR FAILED/PROCESSING counts render with **no**
+  "Open OCR" link, and that OCR `available=false` isolates without breaking peers.
+
+### 4.2 Local results — honest scope
+
+This environment has **no Maven cache and no access to Maven Central**, so the JVM module cannot be
+compiled or tested here; backend verification is **static review** (constructor arity, all three DTO
+call-sites updated, reflection-guard allow-set/records, migration column/index/backfill, entity↔DDL
+length parity) plus the **first PR CI run as the authoritative gate**. `nodes.metadata` was confirmed
+`jsonb` (entity `columnDefinition="jsonb"` + migration `003` `type="JSONB"`) and the backfill join
+(`documents.id = nodes.id`, JOINED inheritance) confirmed by hand. The frontend card test was run
+locally (`react-scripts test`) once dependencies installed — see the PR run for the recorded result.
+
+### 4.3 CI — the authoritative gate
+
+CI compiles the module under `ddl-auto: validate` and boots Liquibase against Testcontainers
+Postgres in the repository/integration tests, so migration 095 — **including** the Postgres-only
+backfill — is exercised there (it cannot be on the no-DB unit/controller tests, which mock the
+service). Treat the first green PR run as the gate.
+
+## 5. Boundaries / out of scope
+
+- **No new endpoint, no replay/retry** — observability only, reusing the existing
+  `GET /api/v1/admin/failure-inventory`.
+- **No raw OCR failure detail** — counts only; per-document OCR state stays on the document surfaces.
+- **No backfill on non-Postgres** — the column is populated going forward by `OcrQueueService`;
+  only the historical backfill is Postgres-gated.
+- **#4 (Mail ERROR index)** stays decision-gated (awaits the 4a privacy/retention decision);
+  **#2 / #5** unchanged. This slice is single-revert (one changeset + one column + one DTO field +
+  card + tests).
+
+## 6. Known follow-up (non-blocking)
+
+`FailureInventoryService` pins the OCR status vocabulary (`"FAILED"`, `"PROCESSING"`) as local
+constants that must match the literals `OcrQueueService` writes. They match today; if that
+vocabulary ever drifts, the card would silently read 0 with nothing failing. A future tidy could
+hoist these to a single shared constant (or a pin-test) to close that silent-failure surface. Left
+out here to keep the slice single-revert.

--- a/ecm-core/src/main/java/com/ecm/core/entity/Document.java
+++ b/ecm-core/src/main/java/com/ecm/core/entity/Document.java
@@ -14,7 +14,8 @@ import java.util.UUID;
 @Entity
 @Table(name = "documents", indexes = {
     @Index(name = "idx_document_content_id", columnList = "content_id"),
-    @Index(name = "idx_document_mime_type", columnList = "mime_type")
+    @Index(name = "idx_document_mime_type", columnList = "mime_type"),
+    @Index(name = "idx_document_ocr_status", columnList = "ocr_status")
 })
 @DiscriminatorValue("DOCUMENT")
 @EqualsAndHashCode(callSuper = true, exclude = {"versions", "currentVersion"})
@@ -35,7 +36,16 @@ public class Document extends Node {
     
     @Column(name = "encoding")
     private String encoding;
-    
+
+    /**
+     * Indexed mirror of the OCR state otherwise stored in {@code metadata["ocrStatus"]}
+     * (READY|PROCESSING|FAILED). Written by {@code OcrQueueService} on every OCR transition so the
+     * Failure Inventory can count FAILED/PROCESSING documents index-first (idx_document_ocr_status)
+     * rather than scanning the jsonb metadata. Nullable: documents that never went through OCR stay null.
+     */
+    @Column(name = "ocr_status", length = 32)
+    private String ocrStatus;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "current_version_id")
     private Version currentVersion;

--- a/ecm-core/src/main/java/com/ecm/core/failureinventory/FailureInventoryService.java
+++ b/ecm-core/src/main/java/com/ecm/core/failureinventory/FailureInventoryService.java
@@ -1,12 +1,14 @@
 package com.ecm.core.failureinventory;
 
 import com.ecm.core.failureinventory.FailureInventorySummaryDto.MailFetchErrors;
+import com.ecm.core.failureinventory.FailureInventorySummaryDto.OcrFailures;
 import com.ecm.core.failureinventory.FailureInventorySummaryDto.PreviewDeadLetter;
 import com.ecm.core.failureinventory.FailureInventorySummaryDto.TransferFailures;
 import com.ecm.core.preview.PreviewDeadLetterRegistry;
 import com.ecm.core.preview.PreviewDeadLetterRegistry.DeadLetterEntry;
 import com.ecm.core.queuebacklog.QueueBacklogObservabilityService;
 import com.ecm.core.queuebacklog.QueueBacklogSummaryDto;
+import com.ecm.core.repository.DocumentRepository;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
@@ -18,11 +20,14 @@ import org.springframework.stereotype.Service;
 /**
  * Read-only cross-subsystem failure-inventory aggregator (taskbook §4 first-cut, §7 ratified).
  *
- * <p>Deliberately thin: the only NEW computation is the preview dead-letter count (+ a non-PII category
- * tally and the latest failure time) read O(1) from {@link PreviewDeadLetterRegistry}. Transfer FAILED and
- * mail account-level ERROR counts are <b>reused</b> from {@link QueueBacklogObservabilityService#getSummary()}
- * (called once; its per-source {@code available} flags are propagated) — this service never re-implements or
- * re-indexes those, and never reads {@code mail_processed_messages} or {@code nodes.metadata}.
+ * <p>Deliberately thin. Two NEW cheap computations: the preview dead-letter count (+ a non-PII category
+ * tally and the latest failure time) read O(1) from {@link PreviewDeadLetterRegistry}; and the OCR
+ * FAILED/PROCESSING document counts (taskbook #3, Option A) read index-first from {@code idx_document_ocr_status}
+ * via {@link DocumentRepository#countByOcrStatus(String)} — two O(1) index counts, NOT a {@code nodes.metadata}
+ * jsonb scan. Transfer FAILED and mail account-level ERROR counts are <b>reused</b> from
+ * {@link QueueBacklogObservabilityService#getSummary()} (called once; its per-source {@code available} flags are
+ * propagated) — this service never re-implements or re-indexes those, and never reads
+ * {@code mail_processed_messages}.
  *
  * <p>Every source is isolated: a failure of one source yields {@code available=false} for that source only
  * and never throws (§6 / §5A), keeping the AdminDashboard card stable.
@@ -33,15 +38,22 @@ public class FailureInventoryService {
     /** {@code list(int)} clamps to 1..500; this bounds the category-tally sample cheaply. */
     private static final int CATEGORY_SAMPLE_LIMIT = 500;
 
+    /** OCR states mirrored onto {@code documents.ocr_status} by {@code OcrQueueService}; only failures/in-flight are counted. */
+    private static final String OCR_STATUS_FAILED = "FAILED";
+    private static final String OCR_STATUS_PROCESSING = "PROCESSING";
+
     private final QueueBacklogObservabilityService queueBacklogObservabilityService;
     private final PreviewDeadLetterRegistry previewDeadLetterRegistry;
+    private final DocumentRepository documentRepository;
 
     public FailureInventoryService(
         QueueBacklogObservabilityService queueBacklogObservabilityService,
-        PreviewDeadLetterRegistry previewDeadLetterRegistry
+        PreviewDeadLetterRegistry previewDeadLetterRegistry,
+        DocumentRepository documentRepository
     ) {
         this.queueBacklogObservabilityService = queueBacklogObservabilityService;
         this.previewDeadLetterRegistry = previewDeadLetterRegistry;
+        this.documentRepository = documentRepository;
     }
 
     public FailureInventorySummaryDto getSummary() {
@@ -56,7 +68,8 @@ public class FailureInventoryService {
         return new FailureInventorySummaryDto(
             previewDeadLetter(),
             transferFailures(backlog),
-            mailFetchErrors(backlog)
+            mailFetchErrors(backlog),
+            ocrFailures()
         );
     }
 
@@ -94,5 +107,20 @@ public class FailureInventoryService {
             return new MailFetchErrors(false, 0L);
         }
         return new MailFetchErrors(true, backlog.mail().errors());
+    }
+
+    /**
+     * NEW signal (taskbook #3, Option A): OCR FAILED / PROCESSING document counts read index-first from
+     * {@code idx_document_ocr_status} (two O(1) counts, no jsonb metadata scan). Count only — no document
+     * name, text, or failure reason. Isolated: any failure yields {@code available=false} and never throws.
+     */
+    private OcrFailures ocrFailures() {
+        try {
+            long failed = documentRepository.countByOcrStatus(OCR_STATUS_FAILED);
+            long running = documentRepository.countByOcrStatus(OCR_STATUS_PROCESSING);
+            return new OcrFailures(true, failed, running);
+        } catch (RuntimeException ex) {
+            return new OcrFailures(false, 0L, 0L);
+        }
     }
 }

--- a/ecm-core/src/main/java/com/ecm/core/failureinventory/FailureInventorySummaryDto.java
+++ b/ecm-core/src/main/java/com/ecm/core/failureinventory/FailureInventorySummaryDto.java
@@ -29,7 +29,8 @@ import java.util.Map;
 public record FailureInventorySummaryDto(
     PreviewDeadLetter preview,
     TransferFailures transfer,
-    MailFetchErrors mail
+    MailFetchErrors mail,
+    OcrFailures ocr
 ) {
 
     /**
@@ -55,5 +56,17 @@ public record FailureInventorySummaryDto(
     public record MailFetchErrors(
         boolean available,
         long errorAccountCount
+    ) {}
+
+    /**
+     * OCR document-processing failures (taskbook #3, Option A) — index-first counts of documents stuck in
+     * {@code FAILED} / {@code PROCESSING}, read O(1) from {@code idx_document_ocr_status} (NOT a jsonb
+     * metadata scan). Count only — carries no document name, text, or failure reason (those stay in the
+     * deep OCR/document surfaces). {@code available=false} if the count source is unreachable.
+     */
+    public record OcrFailures(
+        boolean available,
+        long failedCount,
+        long runningCount
     ) {}
 }

--- a/ecm-core/src/main/java/com/ecm/core/ocr/OcrQueueService.java
+++ b/ecm-core/src/main/java/com/ecm/core/ocr/OcrQueueService.java
@@ -321,6 +321,7 @@ public class OcrQueueService {
 
         Map<String, Object> metadata = document.getMetadata();
         metadata.put(META_OCR_STATUS, "READY");
+        document.setOcrStatus("READY"); // indexed mirror for the Failure Inventory (idx_document_ocr_status)
         metadata.remove(META_OCR_FAILURE_REASON);
         metadata.put(META_OCR_LAST_UPDATED, Instant.now().toString());
         metadata.put(META_OCR_PROVIDER, "ml-service");
@@ -413,6 +414,7 @@ public class OcrQueueService {
         try {
             Map<String, Object> metadata = document.getMetadata();
             metadata.put(META_OCR_STATUS, status);
+            document.setOcrStatus(status); // indexed mirror for the Failure Inventory (idx_document_ocr_status)
             if (failureReason == null || failureReason.isBlank()) {
                 metadata.remove(META_OCR_FAILURE_REASON);
             } else {

--- a/ecm-core/src/main/java/com/ecm/core/repository/DocumentRepository.java
+++ b/ecm-core/src/main/java/com/ecm/core/repository/DocumentRepository.java
@@ -22,6 +22,14 @@ public interface DocumentRepository extends JpaRepository<Document, UUID>, JpaSp
     
     List<Document> findByMimeType(String mimeType);
 
+    /**
+     * Index-first count of non-deleted documents in a given OCR state, e.g. {@code FAILED} /
+     * {@code PROCESSING} for the Failure Inventory. Backed by {@code idx_document_ocr_status} — O(1)/index
+     * scan, NOT an O(n) jsonb metadata scan.
+     */
+    @Query("SELECT COUNT(d) FROM Document d WHERE d.ocrStatus = :status AND d.deleted = false")
+    long countByOcrStatus(@Param("status") String status);
+
     Page<Document> findByDeletedFalse(Pageable pageable);
     
     Page<Document> findByMimeTypeIn(List<String> mimeTypes, Pageable pageable);

--- a/ecm-core/src/main/resources/db/changelog/changes/095-add-document-ocr-status.xml
+++ b/ecm-core/src/main/resources/db/changelog/changes/095-add-document-ocr-status.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <changeSet id="095-add-document-ocr-status" author="failure-inventory-ocr">
+        <comment>
+            Failure Inventory #3 (Option A): promote OCR state — today an UNINDEXED
+            nodes.metadata["ocrStatus"] jsonb key (READY|PROCESSING|FAILED) — to a dedicated,
+            indexed documents.ocr_status column, so the Failure Inventory can count FAILED/PROCESSING
+            OCR documents index-first (O(1) via idx_document_ocr_status) instead of an O(n) metadata
+            scan. OcrQueueService writes the column on every OCR transition; this backfills existing
+            rows once. Nullable — documents that never went through OCR stay null.
+        </comment>
+
+        <addColumn tableName="documents">
+            <column name="ocr_status" type="varchar(32)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <createIndex indexName="idx_document_ocr_status" tableName="documents">
+            <column name="ocr_status"/>
+        </createIndex>
+
+        <!-- One-time backfill from the existing jsonb metadata key. metadata lives on the JOINED parent
+             "nodes" table (documents.id = nodes.id), so join across. Postgres-only (metadata is jsonb);
+             on any other DBMS the column is populated going forward by OcrQueueService. -->
+        <sql dbms="postgresql">
+            UPDATE documents d SET ocr_status = n.metadata->>'ocrStatus'
+            FROM nodes n WHERE n.id = d.id AND n.metadata IS NOT NULL
+        </sql>
+
+        <rollback>
+            <dropIndex indexName="idx_document_ocr_status" tableName="documents"/>
+            <dropColumn tableName="documents" columnName="ocr_status"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/ecm-core/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/ecm-core/src/main/resources/db/changelog/db.changelog-master.xml
@@ -105,6 +105,7 @@
     <include file="db/changelog/changes/092-add-site-invitation-send-tracking.xml"/>
     <include file="db/changelog/changes/093-add-oauth-credential-revoke-endpoint.xml"/>
     <include file="db/changelog/changes/094-add-legal-hold-release-reason.xml"/>
+    <include file="db/changelog/changes/095-add-document-ocr-status.xml"/>
     <include file="db/changelog/changes/007-insert-initial-data.xml"/>
 
 </databaseChangeLog>

--- a/ecm-core/src/test/java/com/ecm/core/controller/FailureInventoryAdminControllerSecurityTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/FailureInventoryAdminControllerSecurityTest.java
@@ -65,7 +65,8 @@ class FailureInventoryAdminControllerSecurityTest {
         return new FailureInventorySummaryDto(
             new FailureInventorySummaryDto.PreviewDeadLetter(true, 0L, Map.of(), null),
             new FailureInventorySummaryDto.TransferFailures(true, 0L),
-            new FailureInventorySummaryDto.MailFetchErrors(true, 0L));
+            new FailureInventorySummaryDto.MailFetchErrors(true, 0L),
+            new FailureInventorySummaryDto.OcrFailures(true, 0L, 0L));
     }
 
     @Test

--- a/ecm-core/src/test/java/com/ecm/core/controller/FailureInventoryAdminControllerTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/FailureInventoryAdminControllerTest.java
@@ -46,7 +46,8 @@ class FailureInventoryAdminControllerTest {
             new FailureInventorySummaryDto.PreviewDeadLetter(
                 true, 5L, Map.of("TIMEOUT", 3L, "UNKNOWN", 2L), Instant.parse("2026-06-29T12:00:00Z")),
             new FailureInventorySummaryDto.TransferFailures(true, 4L),
-            new FailureInventorySummaryDto.MailFetchErrors(true, 2L)));
+            new FailureInventorySummaryDto.MailFetchErrors(true, 2L),
+            new FailureInventorySummaryDto.OcrFailures(true, 6L, 1L)));
 
         mockMvc.perform(get("/api/v1/admin/failure-inventory"))
             .andExpect(status().isOk())
@@ -58,6 +59,9 @@ class FailureInventoryAdminControllerTest {
             .andExpect(jsonPath("$.transfer.available").value(true))
             .andExpect(jsonPath("$.transfer.failedCount").value(4))
             .andExpect(jsonPath("$.mail.available").value(true))
-            .andExpect(jsonPath("$.mail.errorAccountCount").value(2));
+            .andExpect(jsonPath("$.mail.errorAccountCount").value(2))
+            .andExpect(jsonPath("$.ocr.available").value(true))
+            .andExpect(jsonPath("$.ocr.failedCount").value(6))
+            .andExpect(jsonPath("$.ocr.runningCount").value(1));
     }
 }

--- a/ecm-core/src/test/java/com/ecm/core/failureinventory/FailureInventoryServiceTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/failureinventory/FailureInventoryServiceTest.java
@@ -4,6 +4,7 @@ import com.ecm.core.preview.PreviewDeadLetterRegistry;
 import com.ecm.core.preview.PreviewDeadLetterRegistry.DeadLetterEntry;
 import com.ecm.core.queuebacklog.QueueBacklogObservabilityService;
 import com.ecm.core.queuebacklog.QueueBacklogSummaryDto;
+import com.ecm.core.repository.DocumentRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -16,15 +17,18 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class FailureInventoryServiceTest {
 
     private final QueueBacklogObservabilityService queueBacklog = mock(QueueBacklogObservabilityService.class);
     private final PreviewDeadLetterRegistry previewDeadLetterRegistry = mock(PreviewDeadLetterRegistry.class);
+    private final DocumentRepository documentRepository = mock(DocumentRepository.class);
 
     private final FailureInventoryService service =
-        new FailureInventoryService(queueBacklog, previewDeadLetterRegistry);
+        new FailureInventoryService(queueBacklog, previewDeadLetterRegistry, documentRepository);
 
     private static DeadLetterEntry entry(String category, Instant failedAt) {
         // The entry CARRIES raw `reason` text — the service must never let it reach the DTO.
@@ -51,6 +55,8 @@ class FailureInventoryServiceTest {
         Instant t3 = Instant.parse("2026-06-29T12:00:00Z");
         when(previewDeadLetterRegistry.list(anyInt())).thenReturn(List.of(
             entry("TIMEOUT", t1), entry("TIMEOUT", t2), entry("UNKNOWN", t3)));
+        when(documentRepository.countByOcrStatus("FAILED")).thenReturn(5L);
+        when(documentRepository.countByOcrStatus("PROCESSING")).thenReturn(2L);
 
         FailureInventorySummaryDto dto = service.getSummary();
 
@@ -59,6 +65,10 @@ class FailureInventoryServiceTest {
         assertThat(dto.preview().deadLetterCount()).isEqualTo(3L);
         assertThat(dto.preview().categoryTally()).containsEntry("TIMEOUT", 2L).containsEntry("UNKNOWN", 1L);
         assertThat(dto.preview().latestFailedAt()).isEqualTo(t3);
+        // NEW signal: OCR FAILED/PROCESSING counts (index-first)
+        assertThat(dto.ocr().available()).isTrue();
+        assertThat(dto.ocr().failedCount()).isEqualTo(5L);
+        assertThat(dto.ocr().runningCount()).isEqualTo(2L);
         // REUSED counts
         assertThat(dto.transfer().available()).isTrue();
         assertThat(dto.transfer().failedCount()).isEqualTo(4L);
@@ -71,6 +81,7 @@ class FailureInventoryServiceTest {
     void failingSourceIsIsolated() {
         when(previewDeadLetterRegistry.getItemCount()).thenThrow(new RuntimeException("redis down"));
         when(queueBacklog.getSummary()).thenThrow(new RuntimeException("backlog down"));
+        when(documentRepository.countByOcrStatus("FAILED")).thenThrow(new RuntimeException("db down"));
 
         FailureInventorySummaryDto dto = service.getSummary();
 
@@ -82,6 +93,9 @@ class FailureInventoryServiceTest {
         assertThat(dto.transfer().failedCount()).isZero();
         assertThat(dto.mail().available()).isFalse();
         assertThat(dto.mail().errorAccountCount()).isZero();
+        assertThat(dto.ocr().available()).isFalse();
+        assertThat(dto.ocr().failedCount()).isZero();
+        assertThat(dto.ocr().runningCount()).isZero();
     }
 
     @Test
@@ -101,21 +115,61 @@ class FailureInventoryServiceTest {
     }
 
     @Test
+    @DisplayName("OCR counts are read index-first via countByOcrStatus (FAILED + PROCESSING), count only")
+    void ocrCountsAreIndexFirst() {
+        when(queueBacklog.getSummary()).thenReturn(backlog(true, 0L, 0L));
+        when(previewDeadLetterRegistry.getItemCount()).thenReturn(0);
+        when(previewDeadLetterRegistry.list(anyInt())).thenReturn(List.of());
+        when(documentRepository.countByOcrStatus("FAILED")).thenReturn(7L);
+        when(documentRepository.countByOcrStatus("PROCESSING")).thenReturn(3L);
+
+        FailureInventorySummaryDto dto = service.getSummary();
+
+        assertThat(dto.ocr().available()).isTrue();
+        assertThat(dto.ocr().failedCount()).isEqualTo(7L);
+        assertThat(dto.ocr().runningCount()).isEqualTo(3L);
+        verify(documentRepository).countByOcrStatus("FAILED");
+        verify(documentRepository).countByOcrStatus("PROCESSING");
+        verifyNoMoreInteractions(documentRepository);
+    }
+
+    @Test
+    @DisplayName("an OCR DB failure isolates to ocr.available=false; other sources stay healthy")
+    void ocrSourceFailsClosedIndependently() {
+        when(queueBacklog.getSummary()).thenReturn(backlog(true, 4L, 2L));
+        when(previewDeadLetterRegistry.getItemCount()).thenReturn(1);
+        when(previewDeadLetterRegistry.list(anyInt())).thenReturn(List.of());
+        when(documentRepository.countByOcrStatus("FAILED")).thenThrow(new RuntimeException("db down"));
+
+        FailureInventorySummaryDto dto = service.getSummary();
+
+        assertThat(dto.ocr().available()).isFalse();
+        assertThat(dto.ocr().failedCount()).isZero();
+        assertThat(dto.ocr().runningCount()).isZero();
+        // peers unaffected
+        assertThat(dto.transfer().available()).isTrue();
+        assertThat(dto.mail().available()).isTrue();
+        assertThat(dto.preview().available()).isTrue();
+    }
+
+    @Test
     @DisplayName("§5A PII guard: the DTO exposes ONLY count/timestamp/type/category — no raw failure text fields")
     void dtoExposesNoRawFailureText() {
         Set<String> forbidden = Set.of(
             "reason", "subject", "errorMessage", "transportMessage", "errorLog", "lastMessage", "entryReport");
         Set<String> allowed = Set.of(
             // top-level
-            "preview", "transfer", "mail",
+            "preview", "transfer", "mail", "ocr",
             // sub-records
-            "available", "deadLetterCount", "categoryTally", "latestFailedAt", "failedCount", "errorAccountCount");
+            "available", "deadLetterCount", "categoryTally", "latestFailedAt", "failedCount", "errorAccountCount",
+            "runningCount");
 
         List<Class<?>> records = List.of(
             FailureInventorySummaryDto.class,
             FailureInventorySummaryDto.PreviewDeadLetter.class,
             FailureInventorySummaryDto.TransferFailures.class,
-            FailureInventorySummaryDto.MailFetchErrors.class);
+            FailureInventorySummaryDto.MailFetchErrors.class,
+            FailureInventorySummaryDto.OcrFailures.class);
 
         for (Class<?> rec : records) {
             for (RecordComponent c : rec.getRecordComponents()) {

--- a/ecm-frontend/src/components/admin/FailureInventoryCard.test.tsx
+++ b/ecm-frontend/src/components/admin/FailureInventoryCard.test.tsx
@@ -21,6 +21,7 @@ const summary: FailureInventorySummary = {
   },
   transfer: { available: true, failedCount: 4 },
   mail: { available: true, errorAccountCount: 2 },
+  ocr: { available: true, failedCount: 6, runningCount: 1 },
 };
 
 const renderCard = () =>
@@ -33,7 +34,7 @@ const renderCard = () =>
 describe('FailureInventoryCard', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('renders the three failure panels with data + a category tally chip', async () => {
+  it('renders the four failure panels with data + a category tally chip', async () => {
     mockedGet.mockResolvedValueOnce(summary);
 
     renderCard();
@@ -41,12 +42,41 @@ describe('FailureInventoryCard', () => {
     expect(await screen.findByText('Preview dead-letters')).toBeTruthy();
     expect(screen.getByText('Transfer replication')).toBeTruthy();
     expect(screen.getByText('Mail fetch')).toBeTruthy();
+    expect(screen.getByText('OCR processing')).toBeTruthy();
     // category tally chip (non-PII)
     expect(screen.getByText('TIMEOUT: 3')).toBeTruthy();
-    // links out to the deep surfaces
+    // links out to the deep surfaces (OCR has none — it shows a caption instead)
     expect(screen.getByText('Open preview diagnostics')).toBeTruthy();
     expect(screen.getByText('Open transfer jobs')).toBeTruthy();
     expect(screen.getByText('Open mail diagnostics')).toBeTruthy();
+    expect(screen.getByText(/Per-document OCR state/i)).toBeTruthy();
+  });
+
+  it('renders OCR FAILED + PROCESSING counts (no fake deep-surface link)', async () => {
+    mockedGet.mockResolvedValueOnce(summary);
+
+    renderCard();
+
+    expect(await screen.findByText('OCR processing')).toBeTruthy();
+    // count-only, index-first failed + processing values are surfaced
+    expect(screen.getByText(/Failed:/)).toBeTruthy();
+    expect(screen.getByText('6')).toBeTruthy();
+    // OCR intentionally has no "Open ..." deep-surface link
+    expect(screen.queryByText(/Open OCR/i)).toBeNull();
+  });
+
+  it('shows OCR unavailable in isolation without breaking peers', async () => {
+    mockedGet.mockResolvedValueOnce({
+      ...summary,
+      ocr: { available: false, failedCount: 0, runningCount: 0 },
+    });
+
+    renderCard();
+
+    expect(await screen.findByText('OCR processing')).toBeTruthy();
+    expect(screen.getByText('unavailable')).toBeTruthy();
+    // peers still render
+    expect(screen.getByText('Mail fetch')).toBeTruthy();
   });
 
   it('renders a per-subsystem "unavailable" note without breaking the other panels', async () => {

--- a/ecm-frontend/src/components/admin/FailureInventoryCard.tsx
+++ b/ecm-frontend/src/components/admin/FailureInventoryCard.tsx
@@ -36,6 +36,11 @@ export interface FailureInventorySummary {
     available: boolean;
     errorAccountCount: number;
   };
+  ocr: {
+    available: boolean;
+    failedCount: number;
+    runningCount: number;
+  };
 }
 
 const fmtTime = (iso: string | null): string => (iso ? new Date(iso).toLocaleString() : '—');
@@ -89,7 +94,7 @@ const FailureInventoryCard: React.FC = () => {
           Failure Inventory
         </Typography>
         <Typography variant="body2" color="text.secondary" gutterBottom>
-          Read-only cross-subsystem failure triage (preview dead-letters · transfer failures · mail fetch errors).
+          Read-only cross-subsystem failure triage (preview dead-letters · transfer failures · mail fetch errors · OCR failures).
           Counts only — open the linked deep surface for detail. Observability only — no replay or retry.
         </Typography>
         {loading && (
@@ -147,6 +152,21 @@ const FailureInventoryCard: React.FC = () => {
               <Link component={RouterLink} to="/admin/mail" variant="body2">
                 Open mail diagnostics
               </Link>
+            </Box>
+
+            <Box>
+              <Typography variant="subtitle2">OCR processing</Typography>
+              {data.ocr.available ? (
+                <Typography variant="body2" color="text.secondary">
+                  Failed: <b>{data.ocr.failedCount}</b> · Processing: <b>{data.ocr.runningCount}</b>
+                </Typography>
+              ) : (
+                <Unavailable />
+              )}
+              {/* OCR has no dedicated admin deep-surface; per-document OCR state lives on each document. */}
+              <Typography variant="caption" color="text.disabled" display="block">
+                Per-document OCR state is shown on each document.
+              </Typography>
             </Box>
           </Stack>
         )}


### PR DESCRIPTION
## What & why

Closes taskbook item **#3** (`DEVELOPMENT_FAILURE_INVENTORY_OCR_MAIL_INDEX_PRIVACY_DECISION_TASKBOOK_20260629.md`) with the recommended **Option A**: promote OCR state — today an **unindexed** `nodes.metadata["ocrStatus"]` jsonb key (`READY|PROCESSING|FAILED|SKIPPED`) — to a dedicated, indexed `documents.ocr_status` column, and surface FAILED / PROCESSING counts in the §4 cross-subsystem Failure Inventory card.

The new signal is **two O(1) index counts** — no jsonb scan, no new endpoint, no replay/retry.

## Changes

- **Migration 095**: `documents.ocr_status varchar(32)` nullable + `idx_document_ocr_status` + a **Postgres-only** one-time backfill from `nodes.metadata` (`documents.id = nodes.id`, JOINED inheritance); rollback drops index then column.
- **Entity** `Document`: `@Index` + `ocr_status` column (`length=32` to match the DDL; module runs `ddl-auto: validate`).
- **Write path** `OcrQueueService`: mirrors the status onto the column on every OCR transition, so the column stays current on every DBMS regardless of the Postgres backfill.
- **Read path** `DocumentRepository.countByOcrStatus` (index-backed, count only).
- **Aggregator/DTO** `FailureInventoryService.ocrFailures()` + `OcrFailures(available, failedCount, runningCount)` — count only (no name/text/reason); per-source try/catch isolation matches the other three sources.
- **UI** `FailureInventoryCard`: "OCR processing" panel (counts only). Intentionally **no "Open …" deep-surface link** — OCR has no dedicated admin route, so a caption points at the per-document surface instead of linking to nothing.

## PII / §5A

Count + boolean only. The reflection-guard test now also walks `OcrFailures` and asserts every component name is in the explicit allow-set.

## Verification

- **Frontend** card test run locally — 5/5 green (4-panel render + OCR count + OCR isolation + no-fake-link).
- **Backend** verified by static review (constructor arity, all 3 DTO call-sites, reflection-guard allow-set/records, migration column/index/backfill, entity↔DDL length parity, `nodes.metadata` confirmed `jsonb` + backfill join by hand). This environment has **no Maven cache / no Central access**, so the JVM module is compiled + tested by **CI** — which boots Liquibase against Testcontainers Postgres, exercising migration 095 incl. the backfill. **Treat the first green CI run as the gate.**

See `docs/DEV_AND_VERIFICATION_FAILURE_INVENTORY_OCR_INDEX_20260629.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)