### PR TITLE
feat(failure-inventory): mail per-message ERROR index slice (#4 Option A)

### DIFF
--- a/docs/DEV_AND_VERIFICATION_FAILURE_INVENTORY_MAIL_ERROR_INDEX_20260629.md
+++ b/docs/DEV_AND_VERIFICATION_FAILURE_INVENTORY_MAIL_ERROR_INDEX_20260629.md
@@ -1,0 +1,91 @@
+# Failure Inventory #4 — Mail per-message ERROR index (Option A) — Development & Verification (2026-06-29)
+
+## 1. State at a glance
+
+This slice closes taskbook item **#4** from the backlog decision taskbook
+(`DEVELOPMENT_FAILURE_INVENTORY_BACKLOG_2_5_DECISION_TASKBOOK_20260629.md`) using the owner-ratified
+**Option A**: a count-only, index-first per-message mail ERROR signal on the cross-subsystem Failure
+Inventory.
+
+Owner decisions recorded: **4a = count-only** (display count only — no `subject`/`error_message`),
+retention left on the existing shared 90d purge; **4b = a plain single-column `status` index**. Options B
+(redacted per-account/per-rule breakdown), C (raw detail in the card), and D (defer) were not taken.
+
+Two of the three blockers the original taskbook named for #4 were already resolved in code: **retention
+already exists** (`MailProcessedRetentionService`, daily 90d purge — bounds the count), and choosing
+count-only resolves the **PII-display** blocker. The only real work was the **status index**.
+
+## 2. What was built (code-grounded)
+
+The new signal is **one O(index) count**, distinct from the existing account-level fetch-health count.
+
+- **Schema** — `db/changelog/changes/096-add-mail-processed-status-index.xml` (+ master include after 095,
+  before 007-insert): `createIndex idx_mail_processed_status` on `mail_processed_messages(status)`; rollback
+  drops it. `status` (enum `PROCESSED|ERROR`) already existed (migration 014) but was unindexed — only
+  `(account_id, folder, uid)` unique + `(account_id)` were indexed, so a `WHERE status='ERROR'` count was a
+  full scan.
+- **Read path** — `ProcessedMailRepository.countByStatus(ProcessedMail.Status)` — a derived, index-backed
+  count. (No soft-delete column on this log table, so no `deleted` predicate, unlike the OCR/document count.)
+- **Aggregator** — `FailureInventoryService.mailProcessedErrors()` returns
+  `MailProcessedErrors(available, errorCount)` from `countByStatus(ERROR)`, wrapped in try/catch →
+  `MailProcessedErrors(false, 0)` so a DB fault isolates to this one source and never throws.
+- **DTO** — `FailureInventorySummaryDto` gains a 5th component `MailProcessedErrors mailProcessed`
+  (`boolean available, long errorCount`) — count only, **no** `subject`/`error_message`. It is a **different
+  axis** from the reused account-level `MailFetchErrors` (an account can be fetch-healthy yet still have
+  message-level processing errors), so it supplements rather than replaces it.
+- **Wiring boundary** — read **directly** from `ProcessedMailRepository`, **not** routed through
+  `QueueBacklogObservabilityService`, whose contract promises it never queries `mail_processed_messages`.
+- **UI** — `FailureInventoryCard` "Mail" panel now shows two lines: "Accounts in error (fetch)" (existing)
+  and "Messages failed (processing)" (new), each independently available-gated, with the existing link-out to
+  the ADMIN mail diagnostics surface for the raw per-message detail.
+
+## 3. PII / §5A guards — honored
+
+Count + boolean only. The `MailProcessedErrors` record carries no `subject`, `error_message`, sender, or
+account identity. The reflection-guard test walks `MailProcessedErrors` and asserts every component name is
+in the explicit allow-set (`mailProcessed`, `errorCount` added). The read is index-first
+(`idx_mail_processed_status`), not a full-table scan. Raw per-message detail stays in the existing
+ADMIN-gated `GET /api/v1/integration/mail/diagnostics` surface (link-out only).
+
+## 4. Verification
+
+### 4.1 Tests added / updated
+
+Backend (`ecm-core`):
+- `FailureInventoryServiceTest` — 4-arg ctor (mock `ProcessedMailRepository`); the aggregation test stubs +
+  asserts `mailProcessed`; the all-sources-isolation test asserts `mailProcessed.available=false` on a DB
+  fault; two new focused tests: `mailProcessedErrorIsIndexFirst` (verifies `countByStatus(ERROR)` is the only
+  repository interaction) and `mailProcessedSourceFailsClosedIndependently` (per-message fault isolates; the
+  account-level mail signal stays healthy). Reflection-guard allow-set/records extended with
+  `mailProcessed`/`errorCount`/`MailProcessedErrors.class`.
+- `FailureInventoryAdminControllerTest` — DTO built with the 5th arg; new `$.mailProcessed.*` jsonPath
+  assertions.
+- `FailureInventoryAdminControllerSecurityTest` — `sampleSummary()` built with the 5th arg.
+
+Frontend (`ecm-frontend`):
+- `FailureInventoryCard.test.tsx` — `summary` mock gains `mailProcessed`; the panel test asserts both mail
+  axes render; new tests assert the per-message count renders distinct from the account-level line and that a
+  per-message fault isolates without hiding the account-level line. **Run locally — 7/7 green.**
+
+### 4.2 Local results — honest scope
+
+This environment has **no Maven cache and no Central access**, so the JVM module is not compiled/tested here;
+backend verification is **static review** (constructor arity, all DTO call-sites, reflection-guard
+allow-set/records, migration index/rollback, repository derived-query name) plus the **first PR CI run as the
+authoritative gate**. The frontend card test was run locally (`react-scripts test`) — **7/7 green**.
+
+### 4.3 CI — the authoritative gate
+
+CI boots Liquibase against Testcontainers Postgres under `ddl-auto: validate`, so migration 096 is exercised
+there (the no-DB unit/controller tests mock the repository/service). Treat the first green PR run as the gate.
+
+## 5. Boundaries / out of scope
+
+- **No new endpoint, no replay/clear/retry** — observability only, reusing `GET /api/v1/admin/failure-inventory`.
+- **No raw per-message detail** — count only; subject/error text stay in the ADMIN mail diagnostics surface.
+- **No change to `QueueBacklogObservabilityService`** — its account-level signal and its
+  "never queries `mail_processed_messages`" boundary are intact; the per-message count supplements it.
+- **No new retention** — the shared 90d purge already bounds the count. A timestamp (`latestErrorAt`) and a
+  per-account/per-rule breakdown were deliberately left out (the former would argue for a composite
+  `(status, processed_at)` index; the latter is taskbook Option B, a separate decision).
+- **#2 / #5** stay decision-gated and untouched.

--- a/ecm-core/src/main/java/com/ecm/core/failureinventory/FailureInventoryService.java
+++ b/ecm-core/src/main/java/com/ecm/core/failureinventory/FailureInventoryService.java
@@ -1,9 +1,12 @@
 package com.ecm.core.failureinventory;
 
 import com.ecm.core.failureinventory.FailureInventorySummaryDto.MailFetchErrors;
+import com.ecm.core.failureinventory.FailureInventorySummaryDto.MailProcessedErrors;
 import com.ecm.core.failureinventory.FailureInventorySummaryDto.OcrFailures;
 import com.ecm.core.failureinventory.FailureInventorySummaryDto.PreviewDeadLetter;
 import com.ecm.core.failureinventory.FailureInventorySummaryDto.TransferFailures;
+import com.ecm.core.integration.mail.model.ProcessedMail;
+import com.ecm.core.integration.mail.repository.ProcessedMailRepository;
 import com.ecm.core.preview.PreviewDeadLetterRegistry;
 import com.ecm.core.preview.PreviewDeadLetterRegistry.DeadLetterEntry;
 import com.ecm.core.queuebacklog.QueueBacklogObservabilityService;
@@ -20,14 +23,16 @@ import org.springframework.stereotype.Service;
 /**
  * Read-only cross-subsystem failure-inventory aggregator (taskbook §4 first-cut, §7 ratified).
  *
- * <p>Deliberately thin. Two NEW cheap computations: the preview dead-letter count (+ a non-PII category
- * tally and the latest failure time) read O(1) from {@link PreviewDeadLetterRegistry}; and the OCR
- * FAILED/PROCESSING document counts (taskbook #3, Option A) read index-first from {@code idx_document_ocr_status}
- * via {@link DocumentRepository#countByOcrStatus(String)} — two O(1) index counts, NOT a {@code nodes.metadata}
- * jsonb scan. Transfer FAILED and mail account-level ERROR counts are <b>reused</b> from
+ * <p>Deliberately thin. Three NEW cheap computations, each index-first: the preview dead-letter count (+ a
+ * non-PII category tally and the latest failure time) read O(1) from {@link PreviewDeadLetterRegistry}; the OCR
+ * FAILED/PROCESSING document counts (taskbook #3, Option A) via {@link DocumentRepository#countByOcrStatus(String)}
+ * ({@code idx_document_ocr_status}, NOT a {@code nodes.metadata} jsonb scan); and the mail per-message ERROR count
+ * (taskbook #4, Option A) via {@link ProcessedMailRepository#countByStatus} ({@code idx_mail_processed_status},
+ * NOT a full {@code mail_processed_messages} scan — count only, no {@code subject}/{@code error_message}). Transfer
+ * FAILED and mail <i>account-level</i> ERROR counts are <b>reused</b> from
  * {@link QueueBacklogObservabilityService#getSummary()} (called once; its per-source {@code available} flags are
- * propagated) — this service never re-implements or re-indexes those, and never reads
- * {@code mail_processed_messages}.
+ * propagated) — this service never re-implements or re-indexes those. Note the mail per-message ERROR count is a
+ * DIFFERENT axis from the reused account-level fetch-health count, not a duplicate.
  *
  * <p>Every source is isolated: a failure of one source yields {@code available=false} for that source only
  * and never throws (§6 / §5A), keeping the AdminDashboard card stable.
@@ -45,15 +50,18 @@ public class FailureInventoryService {
     private final QueueBacklogObservabilityService queueBacklogObservabilityService;
     private final PreviewDeadLetterRegistry previewDeadLetterRegistry;
     private final DocumentRepository documentRepository;
+    private final ProcessedMailRepository processedMailRepository;
 
     public FailureInventoryService(
         QueueBacklogObservabilityService queueBacklogObservabilityService,
         PreviewDeadLetterRegistry previewDeadLetterRegistry,
-        DocumentRepository documentRepository
+        DocumentRepository documentRepository,
+        ProcessedMailRepository processedMailRepository
     ) {
         this.queueBacklogObservabilityService = queueBacklogObservabilityService;
         this.previewDeadLetterRegistry = previewDeadLetterRegistry;
         this.documentRepository = documentRepository;
+        this.processedMailRepository = processedMailRepository;
     }
 
     public FailureInventorySummaryDto getSummary() {
@@ -69,7 +77,8 @@ public class FailureInventoryService {
             previewDeadLetter(),
             transferFailures(backlog),
             mailFetchErrors(backlog),
-            ocrFailures()
+            ocrFailures(),
+            mailProcessedErrors()
         );
     }
 
@@ -121,6 +130,22 @@ public class FailureInventoryService {
             return new OcrFailures(true, failed, running);
         } catch (RuntimeException ex) {
             return new OcrFailures(false, 0L, 0L);
+        }
+    }
+
+    /**
+     * NEW signal (taskbook #4, Option A): per-message mail ERROR count read index-first from
+     * {@code idx_mail_processed_status} via {@link ProcessedMailRepository#countByStatus} (O(index), no full
+     * {@code mail_processed_messages} scan). Count only — no {@code subject}/{@code error_message} (those stay
+     * in the ADMIN-gated mail diagnostics surface). A DIFFERENT axis from the reused account-level
+     * {@link MailFetchErrors}. Isolated: any failure yields {@code available=false} and never throws.
+     */
+    private MailProcessedErrors mailProcessedErrors() {
+        try {
+            long errorCount = processedMailRepository.countByStatus(ProcessedMail.Status.ERROR);
+            return new MailProcessedErrors(true, errorCount);
+        } catch (RuntimeException ex) {
+            return new MailProcessedErrors(false, 0L);
         }
     }
 }

--- a/ecm-core/src/main/java/com/ecm/core/failureinventory/FailureInventorySummaryDto.java
+++ b/ecm-core/src/main/java/com/ecm/core/failureinventory/FailureInventorySummaryDto.java
@@ -30,7 +30,8 @@ public record FailureInventorySummaryDto(
     PreviewDeadLetter preview,
     TransferFailures transfer,
     MailFetchErrors mail,
-    OcrFailures ocr
+    OcrFailures ocr,
+    MailProcessedErrors mailProcessed
 ) {
 
     /**
@@ -68,5 +69,18 @@ public record FailureInventorySummaryDto(
         boolean available,
         long failedCount,
         long runningCount
+    ) {}
+
+    /**
+     * Mail per-message ERROR backlog (taskbook #4, Option A) — an index-first count of
+     * {@code mail_processed_messages} rows in {@code ERROR}, read from {@code idx_mail_processed_status}
+     * (NOT a full-table scan). This is a DIFFERENT axis from {@link MailFetchErrors}: that is the
+     * account-level fetch-health count (an account can be fetch-healthy yet still have message-level
+     * processing errors). Count only — carries no {@code subject} or {@code error_message} (those stay in
+     * the ADMIN-gated mail diagnostics surface). {@code available=false} if the count source is unreachable.
+     */
+    public record MailProcessedErrors(
+        boolean available,
+        long errorCount
     ) {}
 }

--- a/ecm-core/src/main/java/com/ecm/core/integration/mail/repository/ProcessedMailRepository.java
+++ b/ecm-core/src/main/java/com/ecm/core/integration/mail/repository/ProcessedMailRepository.java
@@ -23,6 +23,14 @@ public interface ProcessedMailRepository extends JpaRepository<ProcessedMail, UU
 
     void deleteByProcessedAtBefore(java.time.LocalDateTime threshold);
 
+    /**
+     * Index-first count of processed-mail rows in a given terminal state, e.g. {@code ERROR} for the
+     * Failure Inventory per-message ERROR backlog (taskbook #4, Option A — count only). Backed by
+     * {@code idx_mail_processed_status} — an index scan, NOT a full {@code mail_processed_messages} scan.
+     * The shared 90d retention purge ({@code MailProcessedRetentionService}) keeps this count bounded.
+     */
+    long countByStatus(ProcessedMail.Status status);
+
     @Query(
         value = """
             SELECT account_id as accountId,

--- a/ecm-core/src/main/resources/db/changelog/changes/096-add-mail-processed-status-index.xml
+++ b/ecm-core/src/main/resources/db/changelog/changes/096-add-mail-processed-status-index.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <changeSet id="096-add-mail-processed-status-index" author="failure-inventory-mail">
+        <comment>
+            Failure Inventory #4 (Option A): index mail_processed_messages.status so the inventory can
+            count per-message ERROR rows index-first (O(index) via idx_mail_processed_status) instead of an
+            O(n) scan. status already exists (migration 014, enum PROCESSED|ERROR) but is unindexed; only
+            (account_id, folder, uid) unique + (account_id) are indexed today. Count only — no subject /
+            error_message is read by the inventory (those stay in the ADMIN-gated mail diagnostics surface).
+            The shared 90d retention purge (MailProcessedRetentionService) keeps the ERROR count bounded.
+        </comment>
+
+        <createIndex indexName="idx_mail_processed_status" tableName="mail_processed_messages">
+            <column name="status"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex indexName="idx_mail_processed_status" tableName="mail_processed_messages"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/ecm-core/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/ecm-core/src/main/resources/db/changelog/db.changelog-master.xml
@@ -106,6 +106,7 @@
     <include file="db/changelog/changes/093-add-oauth-credential-revoke-endpoint.xml"/>
     <include file="db/changelog/changes/094-add-legal-hold-release-reason.xml"/>
     <include file="db/changelog/changes/095-add-document-ocr-status.xml"/>
+    <include file="db/changelog/changes/096-add-mail-processed-status-index.xml"/>
     <include file="db/changelog/changes/007-insert-initial-data.xml"/>
 
 </databaseChangeLog>

--- a/ecm-core/src/test/java/com/ecm/core/controller/FailureInventoryAdminControllerSecurityTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/FailureInventoryAdminControllerSecurityTest.java
@@ -66,7 +66,8 @@ class FailureInventoryAdminControllerSecurityTest {
             new FailureInventorySummaryDto.PreviewDeadLetter(true, 0L, Map.of(), null),
             new FailureInventorySummaryDto.TransferFailures(true, 0L),
             new FailureInventorySummaryDto.MailFetchErrors(true, 0L),
-            new FailureInventorySummaryDto.OcrFailures(true, 0L, 0L));
+            new FailureInventorySummaryDto.OcrFailures(true, 0L, 0L),
+            new FailureInventorySummaryDto.MailProcessedErrors(true, 0L));
     }
 
     @Test

--- a/ecm-core/src/test/java/com/ecm/core/controller/FailureInventoryAdminControllerTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/controller/FailureInventoryAdminControllerTest.java
@@ -47,7 +47,8 @@ class FailureInventoryAdminControllerTest {
                 true, 5L, Map.of("TIMEOUT", 3L, "UNKNOWN", 2L), Instant.parse("2026-06-29T12:00:00Z")),
             new FailureInventorySummaryDto.TransferFailures(true, 4L),
             new FailureInventorySummaryDto.MailFetchErrors(true, 2L),
-            new FailureInventorySummaryDto.OcrFailures(true, 6L, 1L)));
+            new FailureInventorySummaryDto.OcrFailures(true, 6L, 1L),
+            new FailureInventorySummaryDto.MailProcessedErrors(true, 9L)));
 
         mockMvc.perform(get("/api/v1/admin/failure-inventory"))
             .andExpect(status().isOk())
@@ -62,6 +63,8 @@ class FailureInventoryAdminControllerTest {
             .andExpect(jsonPath("$.mail.errorAccountCount").value(2))
             .andExpect(jsonPath("$.ocr.available").value(true))
             .andExpect(jsonPath("$.ocr.failedCount").value(6))
-            .andExpect(jsonPath("$.ocr.runningCount").value(1));
+            .andExpect(jsonPath("$.ocr.runningCount").value(1))
+            .andExpect(jsonPath("$.mailProcessed.available").value(true))
+            .andExpect(jsonPath("$.mailProcessed.errorCount").value(9));
     }
 }

--- a/ecm-core/src/test/java/com/ecm/core/failureinventory/FailureInventoryServiceTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/failureinventory/FailureInventoryServiceTest.java
@@ -2,6 +2,8 @@ package com.ecm.core.failureinventory;
 
 import com.ecm.core.preview.PreviewDeadLetterRegistry;
 import com.ecm.core.preview.PreviewDeadLetterRegistry.DeadLetterEntry;
+import com.ecm.core.integration.mail.model.ProcessedMail;
+import com.ecm.core.integration.mail.repository.ProcessedMailRepository;
 import com.ecm.core.queuebacklog.QueueBacklogObservabilityService;
 import com.ecm.core.queuebacklog.QueueBacklogSummaryDto;
 import com.ecm.core.repository.DocumentRepository;
@@ -26,9 +28,10 @@ class FailureInventoryServiceTest {
     private final QueueBacklogObservabilityService queueBacklog = mock(QueueBacklogObservabilityService.class);
     private final PreviewDeadLetterRegistry previewDeadLetterRegistry = mock(PreviewDeadLetterRegistry.class);
     private final DocumentRepository documentRepository = mock(DocumentRepository.class);
+    private final ProcessedMailRepository processedMailRepository = mock(ProcessedMailRepository.class);
 
     private final FailureInventoryService service =
-        new FailureInventoryService(queueBacklog, previewDeadLetterRegistry, documentRepository);
+        new FailureInventoryService(queueBacklog, previewDeadLetterRegistry, documentRepository, processedMailRepository);
 
     private static DeadLetterEntry entry(String category, Instant failedAt) {
         // The entry CARRIES raw `reason` text — the service must never let it reach the DTO.
@@ -57,6 +60,7 @@ class FailureInventoryServiceTest {
             entry("TIMEOUT", t1), entry("TIMEOUT", t2), entry("UNKNOWN", t3)));
         when(documentRepository.countByOcrStatus("FAILED")).thenReturn(5L);
         when(documentRepository.countByOcrStatus("PROCESSING")).thenReturn(2L);
+        when(processedMailRepository.countByStatus(ProcessedMail.Status.ERROR)).thenReturn(9L);
 
         FailureInventorySummaryDto dto = service.getSummary();
 
@@ -69,6 +73,9 @@ class FailureInventoryServiceTest {
         assertThat(dto.ocr().available()).isTrue();
         assertThat(dto.ocr().failedCount()).isEqualTo(5L);
         assertThat(dto.ocr().runningCount()).isEqualTo(2L);
+        // NEW signal: mail per-message ERROR count (index-first, distinct axis from account-level)
+        assertThat(dto.mailProcessed().available()).isTrue();
+        assertThat(dto.mailProcessed().errorCount()).isEqualTo(9L);
         // REUSED counts
         assertThat(dto.transfer().available()).isTrue();
         assertThat(dto.transfer().failedCount()).isEqualTo(4L);
@@ -82,6 +89,7 @@ class FailureInventoryServiceTest {
         when(previewDeadLetterRegistry.getItemCount()).thenThrow(new RuntimeException("redis down"));
         when(queueBacklog.getSummary()).thenThrow(new RuntimeException("backlog down"));
         when(documentRepository.countByOcrStatus("FAILED")).thenThrow(new RuntimeException("db down"));
+        when(processedMailRepository.countByStatus(ProcessedMail.Status.ERROR)).thenThrow(new RuntimeException("db down"));
 
         FailureInventorySummaryDto dto = service.getSummary();
 
@@ -96,6 +104,8 @@ class FailureInventoryServiceTest {
         assertThat(dto.ocr().available()).isFalse();
         assertThat(dto.ocr().failedCount()).isZero();
         assertThat(dto.ocr().runningCount()).isZero();
+        assertThat(dto.mailProcessed().available()).isFalse();
+        assertThat(dto.mailProcessed().errorCount()).isZero();
     }
 
     @Test
@@ -153,23 +163,57 @@ class FailureInventoryServiceTest {
     }
 
     @Test
+    @DisplayName("mail per-message ERROR is read index-first via countByStatus(ERROR), count only")
+    void mailProcessedErrorIsIndexFirst() {
+        when(queueBacklog.getSummary()).thenReturn(backlog(true, 0L, 0L));
+        when(previewDeadLetterRegistry.getItemCount()).thenReturn(0);
+        when(previewDeadLetterRegistry.list(anyInt())).thenReturn(List.of());
+        when(processedMailRepository.countByStatus(ProcessedMail.Status.ERROR)).thenReturn(11L);
+
+        FailureInventorySummaryDto dto = service.getSummary();
+
+        assertThat(dto.mailProcessed().available()).isTrue();
+        assertThat(dto.mailProcessed().errorCount()).isEqualTo(11L);
+        verify(processedMailRepository).countByStatus(ProcessedMail.Status.ERROR);
+        verifyNoMoreInteractions(processedMailRepository);
+    }
+
+    @Test
+    @DisplayName("a mail-processed DB failure isolates to mailProcessed.available=false; account-level mail stays healthy")
+    void mailProcessedSourceFailsClosedIndependently() {
+        when(queueBacklog.getSummary()).thenReturn(backlog(true, 4L, 2L));
+        when(previewDeadLetterRegistry.getItemCount()).thenReturn(0);
+        when(previewDeadLetterRegistry.list(anyInt())).thenReturn(List.of());
+        when(processedMailRepository.countByStatus(ProcessedMail.Status.ERROR)).thenThrow(new RuntimeException("db down"));
+
+        FailureInventorySummaryDto dto = service.getSummary();
+
+        assertThat(dto.mailProcessed().available()).isFalse();
+        assertThat(dto.mailProcessed().errorCount()).isZero();
+        // the account-level mail signal (distinct axis) is unaffected
+        assertThat(dto.mail().available()).isTrue();
+        assertThat(dto.mail().errorAccountCount()).isEqualTo(2L);
+    }
+
+    @Test
     @DisplayName("§5A PII guard: the DTO exposes ONLY count/timestamp/type/category — no raw failure text fields")
     void dtoExposesNoRawFailureText() {
         Set<String> forbidden = Set.of(
             "reason", "subject", "errorMessage", "transportMessage", "errorLog", "lastMessage", "entryReport");
         Set<String> allowed = Set.of(
             // top-level
-            "preview", "transfer", "mail", "ocr",
+            "preview", "transfer", "mail", "ocr", "mailProcessed",
             // sub-records
             "available", "deadLetterCount", "categoryTally", "latestFailedAt", "failedCount", "errorAccountCount",
-            "runningCount");
+            "runningCount", "errorCount");
 
         List<Class<?>> records = List.of(
             FailureInventorySummaryDto.class,
             FailureInventorySummaryDto.PreviewDeadLetter.class,
             FailureInventorySummaryDto.TransferFailures.class,
             FailureInventorySummaryDto.MailFetchErrors.class,
-            FailureInventorySummaryDto.OcrFailures.class);
+            FailureInventorySummaryDto.OcrFailures.class,
+            FailureInventorySummaryDto.MailProcessedErrors.class);
 
         for (Class<?> rec : records) {
             for (RecordComponent c : rec.getRecordComponents()) {

--- a/ecm-frontend/src/components/admin/FailureInventoryCard.test.tsx
+++ b/ecm-frontend/src/components/admin/FailureInventoryCard.test.tsx
@@ -22,6 +22,7 @@ const summary: FailureInventorySummary = {
   transfer: { available: true, failedCount: 4 },
   mail: { available: true, errorAccountCount: 2 },
   ocr: { available: true, failedCount: 6, runningCount: 1 },
+  mailProcessed: { available: true, errorCount: 9 },
 };
 
 const renderCard = () =>
@@ -41,8 +42,11 @@ describe('FailureInventoryCard', () => {
 
     expect(await screen.findByText('Preview dead-letters')).toBeTruthy();
     expect(screen.getByText('Transfer replication')).toBeTruthy();
-    expect(screen.getByText('Mail fetch')).toBeTruthy();
+    expect(screen.getByText('Mail')).toBeTruthy();
     expect(screen.getByText('OCR processing')).toBeTruthy();
+    // both mail axes render: account-level (fetch) + per-message (processing)
+    expect(screen.getByText(/Accounts in error/)).toBeTruthy();
+    expect(screen.getByText(/Messages failed/)).toBeTruthy();
     // category tally chip (non-PII)
     expect(screen.getByText('TIMEOUT: 3')).toBeTruthy();
     // links out to the deep surfaces (OCR has none — it shows a caption instead)
@@ -76,7 +80,29 @@ describe('FailureInventoryCard', () => {
     expect(await screen.findByText('OCR processing')).toBeTruthy();
     expect(screen.getByText('unavailable')).toBeTruthy();
     // peers still render
-    expect(screen.getByText('Mail fetch')).toBeTruthy();
+    expect(screen.getByText('Mail')).toBeTruthy();
+  });
+
+  it('renders the per-message mail ERROR count, distinct from the account-level fetch count', async () => {
+    mockedGet.mockResolvedValueOnce(summary);
+
+    renderCard();
+
+    expect(await screen.findByText(/Messages failed/)).toBeTruthy();
+    expect(screen.getByText('9')).toBeTruthy(); // per-message errorCount
+    expect(screen.getByText(/Accounts in error/)).toBeTruthy(); // account-level still shown
+  });
+
+  it('isolates a per-message mail failure without hiding the account-level line', async () => {
+    mockedGet.mockResolvedValueOnce({
+      ...summary,
+      mailProcessed: { available: false, errorCount: 0 },
+    });
+
+    renderCard();
+
+    expect(await screen.findByText(/Accounts in error/)).toBeTruthy();
+    expect(screen.getByText('unavailable')).toBeTruthy();
   });
 
   it('renders a per-subsystem "unavailable" note without breaking the other panels', async () => {

--- a/ecm-frontend/src/components/admin/FailureInventoryCard.tsx
+++ b/ecm-frontend/src/components/admin/FailureInventoryCard.tsx
@@ -41,6 +41,10 @@ export interface FailureInventorySummary {
     failedCount: number;
     runningCount: number;
   };
+  mailProcessed: {
+    available: boolean;
+    errorCount: number;
+  };
 }
 
 const fmtTime = (iso: string | null): string => (iso ? new Date(iso).toLocaleString() : '—');
@@ -94,7 +98,7 @@ const FailureInventoryCard: React.FC = () => {
           Failure Inventory
         </Typography>
         <Typography variant="body2" color="text.secondary" gutterBottom>
-          Read-only cross-subsystem failure triage (preview dead-letters · transfer failures · mail fetch errors · OCR failures).
+          Read-only cross-subsystem failure triage (preview dead-letters · transfer failures · mail fetch + message errors · OCR failures).
           Counts only — open the linked deep surface for detail. Observability only — no replay or retry.
         </Typography>
         {loading && (
@@ -141,10 +145,17 @@ const FailureInventoryCard: React.FC = () => {
             </Box>
 
             <Box>
-              <Typography variant="subtitle2">Mail fetch</Typography>
+              <Typography variant="subtitle2">Mail</Typography>
               {data.mail.available ? (
                 <Typography variant="body2" color="text.secondary">
-                  Accounts in error: <b>{data.mail.errorAccountCount}</b>
+                  Accounts in error (fetch): <b>{data.mail.errorAccountCount}</b>
+                </Typography>
+              ) : (
+                <Unavailable />
+              )}
+              {data.mailProcessed.available ? (
+                <Typography variant="body2" color="text.secondary">
+                  Messages failed (processing): <b>{data.mailProcessed.errorCount}</b>
                 </Typography>
               ) : (
                 <Unavailable />


### PR DESCRIPTION
## What & why

Closes taskbook item **#4** with the owner-ratified **Option A**: a **count-only, index-first** per-message mail ERROR signal on the cross-subsystem Failure Inventory. This is a **different axis** from the existing account-level fetch-health count — an account can be fetch-healthy yet still have message-level processing ERRORs the card previously missed.

Owner decisions: **4a = count-only** (no subject/error text), retention left on the existing shared 90d purge; **4b = a plain single-column `status` index**.

Two of the three blockers the original taskbook named for #4 were already resolved in code: **retention already exists** (`MailProcessedRetentionService`, 90d daily purge → bounds the count) and choosing count-only resolves the **PII-display** blocker. The only real work was the status index.

## Changes

- **Migration 096**: `createIndex idx_mail_processed_status` on `mail_processed_messages(status)` + rollback. `status` (enum `PROCESSED|ERROR`) existed since migration 014 but was unindexed.
- **Read path** `ProcessedMailRepository.countByStatus` (index-backed, count only).
- **Aggregator/DTO** `FailureInventoryService.mailProcessedErrors()` + `MailProcessedErrors(available, errorCount)` — count only (no subject/error_message); per-source try/catch isolation. Read **directly** from `ProcessedMailRepository`, **not** via `QueueBacklogObservabilityService` (whose contract forbids touching `mail_processed_messages`).
- **UI** `FailureInventoryCard` "Mail" panel: "Accounts in error (fetch)" + "Messages failed (processing)" lines, each available-gated; link-out unchanged.

## PII / §5A

Count + boolean only. The reflection-guard test walks `MailProcessedErrors` and asserts every component is in the count/time/type allow-set. Raw per-message detail stays in the ADMIN-gated `/api/v1/integration/mail/diagnostics` surface (link-out).

## Verification

- **Frontend** card test run locally — **7/7 green** (both mail axes render; per-message count distinct from account-level; per-message fault isolates without hiding the account line).
- **Backend** verified by static review (constructor arity, all DTO call-sites, reflection-guard, migration index/rollback, derived-query name). No Maven cache / Central here → JVM build is **CI** (Testcontainers Postgres under `ddl-auto: validate` exercises migration 096). **Treat the first green CI run as the gate.**

See `docs/DEV_AND_VERIFICATION_FAILURE_INVENTORY_MAIL_ERROR_INDEX_20260629.md`. Depends conceptually on the backlog decision taskbook (#53); merge stays the owner's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)