### PR TITLE
fix(license): stop placeholder enterprise grants

### DIFF
--- a/docs/DEV_AND_VERIFICATION_LICENSE_FALSE_GRANT_CLOSEOUT_20260629.md
+++ b/docs/DEV_AND_VERIFICATION_LICENSE_FALSE_GRANT_CLOSEOUT_20260629.md
@@ -1,0 +1,48 @@
+# License placeholder false-grant closeout — Development & Verification (2026-06-29)
+
+## 1. Why this slice exists
+
+`LicenseService` was already documented as a display-only placeholder, but its runtime behavior still
+overstated capability: any non-empty `ecm.license.key` except the literal `invalid` produced a hardcoded
+Enterprise license (`WORKFLOW`, `OCR`, `AUDIT`, 100 users, 1000 GB, +1 year). That made the AdminDashboard
+License card look commercially enabled even though no JWT/RSA verification or enforcement path exists.
+
+This slice removes that false-grant behavior. It does **not** implement real licensing.
+
+## 2. What changed
+
+- `LicenseService.validateLicense()` no longer fabricates Enterprise data.
+- Empty key remains Community `valid=true`.
+- Any configured key falls back to Community `valid=false` until signed-license verification exists.
+- Community feature behavior stays unchanged: `BASIC` remains enabled; commercial feature names such as
+  `WORKFLOW` / `OCR` remain disabled.
+- Existing `checkUserLimit()` and `isFeatureEnabled()` enforcement hooks remain non-wired placeholders.
+
+## 3. Boundaries
+
+- No JWT/RSA parsing.
+- No license server.
+- No create-user or feature-route enforcement.
+- No frontend redesign. The existing AdminDashboard License card now receives a truthful backend status
+  instead of a hardcoded Enterprise mock.
+
+## 4. Verification
+
+Targeted unit coverage:
+
+- blank key -> Community, `valid=true`, 5 users, 10 GB, `[BASIC]`;
+- arbitrary configured key -> Community, `valid=false`, no Enterprise feature grant;
+- literal `invalid` -> Community, `valid=false`.
+
+Command used:
+
+```bash
+cd ecm-core
+./mvnw -Dtest=LicenseServiceTest,LicenseControllerSecurityTest test
+```
+
+## 5. Remaining product decisions
+
+Real licensing remains a separate product line: edition model, billable-seat definition, signed-license
+source of truth, expiry/grace behavior, and actual enforcement wiring all still need owner decisions before
+runtime enforcement should be built.

--- a/docs/FEATURE_LICENSING.md
+++ b/docs/FEATURE_LICENSING.md
@@ -2,7 +2,9 @@
 
 > **版本**: 1.1
 > **日期**: 2025-12-10（2026-06-23 状态纠偏）
-> **状态**: ⚠️ **Placeholder / 占位实现** —— 校验逻辑为 mock（硬编码），限制执行（`checkUserLimit` / `isFeatureEnabled`）**未接入、为死代码（NOT enforced yet）**。read-only 复核见 `docs/GAP_AUDIT_LICENSE_ENTITLEMENT_ADMIN_20260623.md`。
+> **状态**: ⚠️ **Placeholder / 占位实现** —— 商业 License 真验签尚未实现；当前不会因任意
+> `ecm.license.key` 授予 Enterprise。限制执行（`checkUserLimit` / `isFeatureEnabled`）**未接入、为死代码（NOT enforced yet）**。
+> read-only 复核见 `docs/GAP_AUDIT_LICENSE_ENTITLEMENT_ADMIN_20260623.md`。
 
 ## 1. 概述
 
@@ -13,9 +15,11 @@
 ### 2.1 License Service (`LicenseService`)
 
 *   **启动检查**: 系统启动时读取 `ecm.license.key`。
-*   **验证逻辑（⚠️ mock，非真验签）**:
+*   **验证逻辑（⚠️ 非真验签，商业授权未启用）**:
     *   没有 Key → 降级为 **Community Edition**（5 用户 / 10GB / 永不过期 / `[BASIC]`）。
-    *   有 Key → **当前并不真正解析或验签**：任何非空且非 `"invalid"` 的 Key 一律硬编码为 **Enterprise**（100 用户 / 1000GB / +1 年 / `[WORKFLOW,OCR,AUDIT]`）；`"invalid"` 或异常一律回退 Community。代码导入了 JWT/RSA 却未使用。`valid` 对外**恒为 `true`**。
+    *   有 Key → **当前并不真正解析或验签，也不授予商业 Edition**：任意配置的 Key 都会被忽略并降级为
+        **Community Edition**；`valid=false` 表示“配置了未被验证的商业 Key”。这避免旧占位逻辑把任意非空 Key
+        硬编码展示成 Enterprise。
 *   **限制执行（⚠️ 当前未接入 / NOT ENFORCED YET —— 死代码）**:
     *   `checkUserLimit()`: 已定义，但**全仓无生产调用者**——用户上限当前并不执行。
     *   `isFeatureEnabled(feature)`: 已定义，但**全仓无生产调用者**——没有任何功能受 License 开关控制；feature 名仅为 `LicenseService` 内的字符串字面量，无枚举 / 注册表。
@@ -30,7 +34,8 @@
 ## 3. 验证方法（当前行为）
 
 1.  **默认状态**: 不配置 License Key → 接口返回 "Community"、`maxUsers=5`。
-2.  **配置 License**: 设置任意非空且非 `invalid` 的 `ECM_LICENSE_KEY`（如 `valid`）→ 接口返回硬编码的 "Enterprise" 信息。**注意：这是 mock 数据，限制并未真正执行**（见 §2.1）。
+2.  **配置 License**: 设置任意非空 `ECM_LICENSE_KEY`（如 `valid`）→ 接口仍返回 "Community" 限制，并返回
+    `valid=false`，表示商业 Key 未被真实验签；不会展示硬编码 Enterprise。
 
 ## 4. 后续计划（若 licensing 成为真需求）
 

--- a/docs/GAP_AUDIT_LICENSE_ENTITLEMENT_ADMIN_20260623.md
+++ b/docs/GAP_AUDIT_LICENSE_ENTITLEMENT_ADMIN_20260623.md
@@ -12,6 +12,11 @@ This doc stays as the **decision record**. Ratified outcome:
 - **Next mainline = Sensitive-Data Logging Audit Phase 1** (genuinely live + high-value).
 - Minimal honest loop = a **doc-only PR** (this gap audit + the `FEATURE_LICENSING.md` correction); after merge, open the logging-audit taskbook. (= §4 path "(C)" plus the existing-doc fix in §2.4.)
 
+**2026-06-29 follow-up closeout:** the most misleading runtime behavior from §2.1 has been removed.
+Configured commercial license keys no longer fabricate a hardcoded Enterprise license; until real signed
+license verification exists, they fall back to Community with `valid=false`. The subsystem remains
+display-only and non-enforcing.
+
 ## 1. What exists today (precise, code-grounded)
 
 - Backend `LicenseService` + `LicenseController` (`GET /api/v1/system/license`, `hasRole('ADMIN')`).
@@ -23,10 +28,11 @@ This doc stays as the **decision record**. Ratified outcome:
 
 Three code-confirmed facts:
 
-1. **Validation is mocked.** `validateLicense()` (L56-84) is explicitly "MVP/Demo… Placeholder logic":
-   any non-blank/non-`"invalid"` key → **hardcoded Enterprise** (100 users / 1000 GB / +1yr / [WORKFLOW,OCR,AUDIT]);
-   empty → Community; `"invalid"` → Community fallback. No JWT/RSA parsing (imports present, unused).
-   **`valid` is always `true`** on every path — the Valid/Invalid chip is decorative.
+1. **Validation is placeholder-only.** Original audit finding: `validateLicense()` treated any
+   non-blank/non-`"invalid"` key as **hardcoded Enterprise** (100 users / 1000 GB / +1yr /
+   [WORKFLOW,OCR,AUDIT]), with `valid=true` on every path. **2026-06-29 closeout:** that false-grant path
+   is removed. Empty key → Community `valid=true`; configured key without real verification → Community
+   `valid=false`. Real JWT/RSA verification is still not implemented.
 2. **Enforcement is DEAD CODE.** Both enforcement methods have **ZERO callers in the whole repo**:
    - `isFeatureEnabled(feature)` — defined (L89), never called → **no feature is license-gated**;
    - `checkUserLimit()` — defined (L104), never called → **the `maxUsers` limit enforces nothing**.

--- a/ecm-core/src/main/java/com/ecm/core/license/LicenseService.java
+++ b/ecm-core/src/main/java/com/ecm/core/license/LicenseService.java
@@ -2,9 +2,6 @@ package com.ecm.core.license;
 
 import com.ecm.core.entity.User;
 import com.ecm.core.repository.UserRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -13,20 +10,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import jakarta.annotation.PostConstruct;
-import java.security.KeyFactory;
-import java.security.PublicKey;
-import java.security.spec.X509EncodedKeySpec;
-import java.util.Base64;
 import java.util.Date;
 
 /**
  * License Service
- * 
- * Enforces commercial licensing constraints:
- * - Expiration date
- * - Maximum users
- * - Maximum storage
- * - Enabled features (e.g. Workflow, OCR)
+ *
+ * <p>Current status: read-only license reporting placeholder. Until signed license verification is
+ * implemented, configured keys must not grant commercial editions.
  */
 @Slf4j
 @Service
@@ -54,43 +44,24 @@ public class LicenseService {
     }
 
     public void validateLicense() {
-        try {
-            // In a real scenario, use RSA verify. 
-            // For MVP/Demo, we assume JWT signed with a secret or simple decoding if public key not set.
-            // Simplified: Treat licenseKey as a JWT-like payload or simple JSON for now if keys missing.
-            
-            // Placeholder logic:
-            if ("invalid".equals(licenseKey)) {
-                throw new IllegalStateException("Invalid license");
-            }
-            
-            // Mock parsing
-            currentLicense = LicenseInfo.builder()
-                .edition("Enterprise")
-                .maxUsers(100)
-                .maxStorageGb(1000)
-                .expirationDate(new Date(System.currentTimeMillis() + 31536000000L)) // +1 year
-                .features(new String[]{"WORKFLOW", "OCR", "AUDIT"})
-                .valid(true)
-                .build();
-                
-            log.info("License validated: {} Edition (Expires: {})", 
-                currentLicense.getEdition(), currentLicense.getExpirationDate());
-
-        } catch (Exception e) {
-            log.error("Failed to validate license", e);
+        if (licenseKey == null || licenseKey.isBlank()) {
             currentLicense = LicenseInfo.communityEdition();
+            return;
         }
+
+        currentLicense = LicenseInfo.communityEdition(false);
+        log.warn(
+            "Commercial license verification is not implemented; ignoring configured license key{} "
+                + "and running in Community Edition mode.",
+            (publicKeyStr == null || publicKeyStr.isBlank()) ? "" : " and public key");
     }
 
     /**
      * Check if a specific feature is enabled by the license.
      */
     public boolean isFeatureEnabled(String feature) {
-        if (currentLicense == null) return false;
-        if ("Community".equals(currentLicense.getEdition())) {
-            // Community has basic features but maybe not advanced ones
-            return !feature.equals("MULTI_TENANCY") && !feature.equals("ADVANCED_AUDIT");
+        if (currentLicense == null || feature == null || currentLicense.getFeatures() == null) {
+            return false;
         }
         for (String f : currentLicense.getFeatures()) {
             if (f.equalsIgnoreCase(feature)) return true;
@@ -125,13 +96,17 @@ public class LicenseService {
         private boolean valid;
 
         public static LicenseInfo communityEdition() {
+            return communityEdition(true);
+        }
+
+        public static LicenseInfo communityEdition(boolean valid) {
             return LicenseInfo.builder()
                 .edition("Community")
                 .maxUsers(5) // Limit for community
                 .maxStorageGb(10)
                 .expirationDate(null) // Never expires
                 .features(new String[]{"BASIC"})
-                .valid(true)
+                .valid(valid)
                 .build();
         }
     }

--- a/ecm-core/src/test/java/com/ecm/core/license/LicenseServiceTest.java
+++ b/ecm-core/src/test/java/com/ecm/core/license/LicenseServiceTest.java
@@ -1,0 +1,57 @@
+package com.ecm.core.license;
+
+import com.ecm.core.license.LicenseService.LicenseInfo;
+import com.ecm.core.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class LicenseServiceTest {
+
+    private LicenseService serviceWithKey(String licenseKey) {
+        LicenseService service = new LicenseService(mock(UserRepository.class));
+        ReflectionTestUtils.setField(service, "licenseKey", licenseKey);
+        ReflectionTestUtils.setField(service, "publicKeyStr", "");
+        service.init();
+        return service;
+    }
+
+    @Test
+    void blankLicenseKeyReportsValidCommunityEdition() {
+        LicenseInfo info = serviceWithKey("").getLicenseInfo();
+
+        assertThat(info.getEdition()).isEqualTo("Community");
+        assertThat(info.isValid()).isTrue();
+        assertThat(info.getMaxUsers()).isEqualTo(5);
+        assertThat(info.getMaxStorageGb()).isEqualTo(10L);
+        assertThat(info.getExpirationDate()).isNull();
+        assertThat(info.getFeatures()).containsExactly("BASIC");
+    }
+
+    @Test
+    void configuredLicenseKeyDoesNotGrantEnterpriseWithoutVerifier() {
+        LicenseService service = serviceWithKey("any-non-empty-key");
+
+        LicenseInfo info = service.getLicenseInfo();
+        assertThat(info.getEdition()).isEqualTo("Community");
+        assertThat(info.isValid()).isFalse();
+        assertThat(info.getMaxUsers()).isEqualTo(5);
+        assertThat(info.getMaxStorageGb()).isEqualTo(10L);
+        assertThat(info.getExpirationDate()).isNull();
+        assertThat(info.getFeatures()).containsExactly("BASIC");
+        assertThat(service.isFeatureEnabled("WORKFLOW")).isFalse();
+        assertThat(service.isFeatureEnabled("OCR")).isFalse();
+        assertThat(service.isFeatureEnabled("BASIC")).isTrue();
+    }
+
+    @Test
+    void invalidLiteralAlsoFallsBackToInvalidCommunityEdition() {
+        LicenseInfo info = serviceWithKey("invalid").getLicenseInfo();
+
+        assertThat(info.getEdition()).isEqualTo("Community");
+        assertThat(info.isValid()).isFalse();
+        assertThat(info.getFeatures()).containsExactly("BASIC");
+    }
+}


### PR DESCRIPTION
## What changed

Stops the license placeholder from granting a fake Enterprise license when `ecm.license.key` is any non-empty value.

- empty key still reports Community with `valid=true`
- configured key now reports Community with `valid=false` until real signed-license verification exists
- `isFeatureEnabled` now reads the declared feature list instead of broadly allowing almost every Community feature
- docs are updated to match the runtime behavior, plus a small dev/verification closeout

## Why

The existing placeholder made the AdminDashboard License card look commercially enabled (`Enterprise`, `WORKFLOW`, `OCR`, `AUDIT`) even though JWT/RSA verification and enforcement wiring do not exist. That was a threat-model honesty bug: display-only mock data was indistinguishable from a real commercial entitlement.

## Validation

```bash
cd ecm-core
./mvnw -Dtest=LicenseServiceTest,LicenseControllerSecurityTest test
```

Result: 7 tests passed.

Also ran `git diff --check` clean.

## Notes

This does not implement real licensing. Seat definition, signed-license source of truth, expiry/grace behavior, and enforcement wiring remain product decisions for a separate slice.
